### PR TITLE
アプリへの導線としてスマートバナー作成

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -14,6 +14,10 @@ const nextConfig: NextConfig = {
   },
   // eslint-disable-next-line @typescript-eslint/require-await
   async headers() {
+    if (process.env.NODE_ENV === 'development') {
+      return [];
+    }
+
     return [
       {
         source: '/(.*)',

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from 'next-themes';
 
 import { Footer } from '@/components/layout/footer';
 import { Sidebar } from '@/components/layout/sidebar';
+import { SmartBanner } from '@/components/ui/smart-banner';
 
 import './globals.css';
 
@@ -33,7 +34,7 @@ export default function RootLayout({
                 <Sidebar />
                 <div className="flex flex-1 flex-col">{children}</div>
               </div>
-
+              <SmartBanner />
               <Footer />
             </div>
           </main>

--- a/apps/web/src/components/ui/smart-banner.tsx
+++ b/apps/web/src/components/ui/smart-banner.tsx
@@ -1,0 +1,69 @@
+import Image from 'next/image';
+import React, { useEffect, useState } from 'react';
+
+export const SmartBanner = () => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isIOS, setIsIOS] = useState(false);
+
+  useEffect(() => {
+    // セッションストレージからバナーの表示状態を取得
+    const isBannerHidden = sessionStorage.getItem('smartBannerHidden');
+
+    // モバイルデバイスの検出
+    const userAgent = window.navigator.userAgent.toLowerCase();
+    const isIOSDevice = /iphone|ipad|ipod/.test(userAgent);
+    const isAndroid = userAgent.includes('android');
+
+    // スタンドアロンモード（PWA）チェック
+    const isStandalone = window.matchMedia('(display-mode: standalone)').matches;
+
+    setIsIOS(isIOSDevice);
+    setIsVisible((isIOSDevice || isAndroid) && !isStandalone && !isBannerHidden);
+  }, []);
+
+  if (!isVisible) return null;
+
+  return (
+    <div className="fixed inset-x-0 top-0 z-50 flex items-center bg-white px-4 py-3 shadow-sm dark:bg-gray-800">
+      <button
+        onClick={() => {
+          setIsVisible(false);
+          // セッションストレージにバナーを閉じたことを記録
+          sessionStorage.setItem('smartBannerHidden', 'true');
+        }}
+        className="absolute left-2 text-gray-500 dark:text-gray-400"
+      >
+        ✕
+      </button>
+
+      <div className="ml-8 flex flex-1 items-center gap-3">
+        <div className="size-10 rounded-xl bg-white">
+          <Image src="/icon-web.png" alt="QuitMate" width={40} height={40} className="rounded-xl" />
+        </div>
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">QuitMate</h3>
+          <p className="text-xs text-gray-600 dark:text-gray-300">Nudge Apps</p>
+          <p className="text-xs text-gray-600 dark:text-gray-300">
+            FREE - {isIOS ? 'On the App Store' : 'In Google Play'}
+          </p>
+        </div>
+        <a
+          href={
+            isIOS
+              ? 'https://apps.apple.com/us/app/%E4%BE%9D%E5%AD%98%E7%97%87%E5%85%8B%E6%9C%8Dsns-quitmate-%E3%82%AF%E3%82%A4%E3%83%83%E3%83%88%E3%83%A1%E3%82%A4%E3%83%88/id6462843097'
+              : 'https://play.google.com/store/apps/details?id=com.quitmate.quitmate'
+          }
+          onClick={() => {
+            setIsVisible(false);
+            sessionStorage.setItem('smartBannerHidden', 'true');
+          }}
+          className={`rounded-md px-4 py-1 text-sm ${
+            isIOS ? 'text-blue-500 dark:text-blue-400' : 'bg-teal-500 text-white'
+          }`}
+        >
+          アプリを開く
+        </a>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
※不要なファイルが変更ファイルに含まれていて消せなかったので、同名プルリクエストがあります。

パッケージ導入に失敗したので自作です。
- 一度閉じるかappstoreに行くと、そのセッション中は表示されない仕様
- iosでは未確認。エミュレーターではstoreに行けないため

入れようとしたパッケージ
- https://github.com/ain/smartbanner.js
- https://github.com/kudago/smart-app-banner

失敗ログ
node_moduleから読み込めないので、publicにjsスクリプトを置き、cssもglobal.css経由でimportした。
なぜか表示されない。onLoad、onError(NextのScript)でログを見ると成功してそう。NetWorkもステータスは304。
わからないので諦めた。