### PR TITLE
feat: ブログOGP画像を白ベースのデザインにリニューアル

### DIFF
--- a/apps/lp/src/pages/og/[...slug].ts
+++ b/apps/lp/src/pages/og/[...slug].ts
@@ -13,18 +13,94 @@ const pages = Object.fromEntries([
   ...blogEn.map((post) => [`en/blog/${post.id.replace(/\.md$/, "")}`, post.data]),
 ]);
 
-// フォントをローカルファイルから読み込み
-const fontBoldPath = path.resolve("./src/assets/fonts/NotoSansJP-Bold.ttf");
-const fontRegularPath = path.resolve("./src/assets/fonts/NotoSansJP-Regular.ttf");
+// フォント読み込み
+const notoBlackPath = path.resolve("./src/assets/fonts/NotoSansJP-ExtraBold.ttf");
+const notoBoldPath = path.resolve("./src/assets/fonts/NotoSansJP-Bold.ttf");
 const interBoldPath = path.resolve("./src/assets/fonts/Inter-Bold.ttf");
-const fontBold = fs.readFileSync(fontBoldPath);
-const fontRegular = fs.readFileSync(fontRegularPath);
+const notoBlack = fs.readFileSync(notoBlackPath);
+const notoBold = fs.readFileSync(notoBoldPath);
 const interBold = fs.readFileSync(interBoldPath);
 
 // ロゴをbase64で埋め込み
 const logoPath = path.resolve("./public/images/icon-web.png");
 const logoBuffer = fs.readFileSync(logoPath);
 const logoBase64 = `data:image/png;base64,${logoBuffer.toString("base64")}`;
+
+// カテゴリーバッジの色（ブログのTailwindクラスと対応）
+const CATEGORY_COLORS: Record<string, { bg: string; text: string }> = {
+  アルコール: { bg: "#dbeafe", text: "#1d4ed8" },
+  Alcohol: { bg: "#dbeafe", text: "#1d4ed8" },
+  ギャンブル: { bg: "#fef3c7", text: "#b45309" },
+  Gambling: { bg: "#fef3c7", text: "#b45309" },
+  過食: { bg: "#fce7f3", text: "#db2777" },
+  "Binge Eating": { bg: "#fce7f3", text: "#db2777" },
+  タバコ: { bg: "#d1fae5", text: "#047857" },
+  Tobacco: { bg: "#d1fae5", text: "#047857" },
+  ポルノ: { bg: "#ede9fe", text: "#7c3aed" },
+  Porn: { bg: "#ede9fe", text: "#7c3aed" },
+  脳と心の科学: { bg: "#e0f2fe", text: "#0369a1" },
+  "Brain Science": { bg: "#e0f2fe", text: "#0369a1" },
+  回復のヒント: { bg: "#dcfce7", text: "#15803d" },
+  "Recovery Tips": { bg: "#dcfce7", text: "#15803d" },
+};
+
+const DEFAULT_CAT_COLOR = { bg: "#f3f4f6", text: "#4b5563" };
+
+/** 中央付近の自然な区切り位置を探す */
+function findNaturalBreak(text: string, target: number): number {
+  const breakAfter = /[、。！？｜・〜】」）〕〉》』：:\-\s]/;
+  const breakBefore = /[【「（〔〈《『]/;
+
+  let bestBreak = -1;
+  let minDistance = Infinity;
+
+  const range = Math.min(8, Math.floor(text.length / 4));
+  const start = Math.max(1, target - range);
+  const end = Math.min(text.length - 1, target + range);
+
+  for (let i = start; i <= end; i++) {
+    const dist = Math.abs(i - target);
+    if (breakAfter.test(text[i]) && dist < minDistance) {
+      bestBreak = i + 1;
+      minDistance = dist;
+    }
+    if (breakBefore.test(text[i]) && dist < minDistance) {
+      bestBreak = i;
+      minDistance = dist;
+    }
+  }
+  return bestBreak;
+}
+
+/** テキストを自然な位置で分割する（長い行は再帰的にさらに分割） */
+function splitText(text: string, maxPerLine: number = 15): string[] {
+  if (text.length <= maxPerLine) return [text];
+
+  // まず中央で2分割
+  const breakPoint = findNaturalBreak(text, Math.floor(text.length / 2));
+  if (breakPoint === -1) return [text];
+
+  const lines = [text.substring(0, breakPoint).trim(), text.substring(breakPoint).trim()];
+
+  // まだ長い行があればさらに分割（自然な区切りがなければ中央で強制分割）
+  const result: string[] = [];
+  for (const line of lines) {
+    if (line.length > maxPerLine) {
+      const subBreak = findNaturalBreak(line, Math.floor(line.length / 2));
+      if (subBreak !== -1) {
+        result.push(line.substring(0, subBreak).trim());
+        result.push(line.substring(subBreak).trim());
+      } else {
+        const mid = Math.floor(line.length / 2);
+        result.push(line.substring(0, mid));
+        result.push(line.substring(mid));
+      }
+      continue;
+    }
+    result.push(line);
+  }
+  return result;
+}
 
 export const getStaticPaths: GetStaticPaths = () => {
   return Object.keys(pages).map((slug) => ({
@@ -40,6 +116,103 @@ export const GET: APIRoute = async ({ params }) => {
     return new Response("Not found", { status: 404 });
   }
 
+  const locale = slug.startsWith("en/") ? "en" : "ja";
+  const titleFontSize = "54px";
+  const titleMaxChars = locale === "ja" ? 15 : 30;
+  const titleLines = splitText(page.title, titleMaxChars);
+
+  const subtitle = page.excerpt.length > 35 ? page.excerpt.substring(0, 35) + "..." : page.excerpt;
+
+  const catColor = CATEGORY_COLORS[page.category ?? ""] ?? DEFAULT_CAT_COLOR;
+
+  // 中央コンテンツ（カテゴリ + タイトル + サブタイトル）
+  const centerChildren: Record<string, unknown>[] = [];
+
+  // カテゴリーバッジ
+  if (page.category) {
+    centerChildren.push({
+      type: "div",
+      props: {
+        style: {
+          display: "flex",
+          justifyContent: "center",
+          marginBottom: "16px",
+        },
+        children: [
+          {
+            type: "div",
+            props: {
+              style: {
+                display: "flex",
+                padding: "5px 20px",
+                borderRadius: "9999px",
+                background: catColor.bg,
+                fontSize: "18px",
+                color: catColor.text,
+                fontWeight: 700,
+              },
+              children: page.category,
+            },
+          },
+        ],
+      },
+    });
+  }
+
+  // タイトル（各行を別要素で描画して中央寄せを維持）
+  centerChildren.push({
+    type: "div",
+    props: {
+      style: {
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        width: "100%",
+      },
+      children: titleLines.map((line: string) => ({
+        type: "div",
+        props: {
+          style: {
+            fontSize: titleFontSize,
+            fontFamily: "Noto Sans JP",
+            fontWeight: 900,
+            color: "#2d2d2d",
+            lineHeight: 1.5,
+            textAlign: "center",
+            letterSpacing: "0.01em",
+          },
+          children: line,
+        },
+      })),
+    },
+  });
+
+  // サブタイトル（1行）
+  centerChildren.push({
+    type: "div",
+    props: {
+      style: {
+        display: "flex",
+        justifyContent: "center",
+        width: "100%",
+        marginTop: "10px",
+      },
+      children: [
+        {
+          type: "div",
+          props: {
+            style: {
+              fontSize: "24px",
+              color: "#888888",
+              textAlign: "center",
+            },
+            children: subtitle,
+          },
+        },
+      ],
+    },
+  });
+
   const svg = await satori(
     {
       type: "div",
@@ -48,146 +221,99 @@ export const GET: APIRoute = async ({ params }) => {
           width: "1200px",
           height: "630px",
           display: "flex",
-          flexDirection: "column",
-          justifyContent: "space-between",
-          padding: "56px 64px",
-          background: "linear-gradient(145deg, #1a5c2e 0%, #143d1c 50%, #0f2d15 100%)",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "linear-gradient(135deg, #f5faf6 0%, #e4f0e8 40%, #d5eade 70%, #c8e4da 100%)",
           fontFamily: "Noto Sans JP",
-          position: "relative",
-          overflow: "hidden",
         },
         children: [
-          // 背景の装飾円
-          {
-            type: "div",
-            props: {
-              style: {
-                position: "absolute",
-                top: "-120px",
-                right: "-80px",
-                width: "400px",
-                height: "400px",
-                borderRadius: "50%",
-                background: "rgba(255, 255, 255, 0.03)",
-              },
-            },
-          },
-          {
-            type: "div",
-            props: {
-              style: {
-                position: "absolute",
-                bottom: "-60px",
-                left: "-40px",
-                width: "250px",
-                height: "250px",
-                borderRadius: "50%",
-                background: "rgba(255, 255, 255, 0.02)",
-              },
-            },
-          },
-          // ヘッダー: ロゴ + QuitMate
+          // 白カード（枠線なし、背景グラデーションが枠の役割）
           {
             type: "div",
             props: {
               style: {
                 display: "flex",
-                alignItems: "center",
-                gap: "10px",
+                flexDirection: "column",
+                width: "1110px",
+                height: "540px",
+                borderRadius: "20px",
+                background: "#ffffff",
+                padding: "36px 60px",
+                position: "relative",
+                overflow: "hidden",
               },
               children: [
+                // ウォーターマークロゴ（背景装飾）
                 {
-                  type: "img",
-                  props: {
-                    src: logoBase64,
-                    width: 64,
-                    height: 64,
-                  },
-                },
-                {
-                  type: "span",
+                  type: "div",
                   props: {
                     style: {
-                      fontSize: "44px",
-                      fontFamily: "Inter",
-                      fontWeight: 700,
-                      color: "#b8e6b0",
-                      letterSpacing: "0.01em",
+                      position: "absolute",
+                      left: "-30px",
+                      bottom: "-30px",
+                      display: "flex",
+                      transform: "rotate(-15deg)",
+                      opacity: 0.055,
                     },
-                    children: "QuitMate",
+                    children: [
+                      {
+                        type: "img",
+                        props: {
+                          src: logoBase64,
+                          width: 300,
+                          height: 300,
+                        },
+                      },
+                    ],
                   },
                 },
-              ],
-            },
-          },
-          // タイトル
-          {
-            type: "div",
-            props: {
-              style: {
-                display: "flex",
-                flex: 1,
-                alignItems: "center",
-              },
-              children: [
+                // 中央コンテンツ
                 {
-                  type: "h1",
+                  type: "div",
                   props: {
                     style: {
-                      fontSize:
-                        page.title.length <= 20
-                          ? "64px"
-                          : page.title.length <= 35
-                            ? "56px"
-                            : "48px",
-                      fontWeight: 700,
-                      color: "#ffffff",
-                      lineHeight: 1.4,
-                      margin: 0,
-                      letterSpacing: "0.01em",
+                      display: "flex",
+                      flexDirection: "column",
+                      flex: 1,
+                      alignItems: "center",
+                      justifyContent: "center",
                     },
-                    children: page.title,
+                    children: centerChildren,
                   },
                 },
-              ],
-            },
-          },
-          // フッター: Blog ラベル
-          {
-            type: "div",
-            props: {
-              style: {
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-              },
-              children: [
+                // ブランディング（中央、大きめ）
                 {
                   type: "div",
                   props: {
                     style: {
                       display: "flex",
                       alignItems: "center",
-                      gap: "8px",
-                      fontSize: "18px",
-                      color: "rgba(255, 255, 255, 0.5)",
-                      fontWeight: 400,
+                      justifyContent: "center",
+                      gap: "6px",
+                      paddingTop: "8px",
                     },
-                    children: "about.quitmate.app/blog",
-                  },
-                },
-                {
-                  type: "div",
-                  props: {
-                    style: {
-                      padding: "6px 20px",
-                      borderRadius: "9999px",
-                      border: "1.5px solid rgba(255, 255, 255, 0.2)",
-                      fontSize: "16px",
-                      color: "rgba(255, 255, 255, 0.6)",
-                      fontWeight: 400,
-                    },
-                    children: "Blog",
+                    children: [
+                      {
+                        type: "img",
+                        props: {
+                          src: logoBase64,
+                          width: 52,
+                          height: 52,
+                        },
+                      },
+                      {
+                        type: "span",
+                        props: {
+                          style: {
+                            fontSize: "34px",
+                            fontFamily: "Inter",
+                            fontWeight: 700,
+                            color: "#333333",
+                          },
+                          children: "QuitMate",
+                        },
+                      },
+                    ],
                   },
                 },
               ],
@@ -201,14 +327,14 @@ export const GET: APIRoute = async ({ params }) => {
       height: 630,
       fonts: [
         { name: "Inter", data: interBold, weight: 700, style: "normal" as const },
-        { name: "Noto Sans JP", data: fontBold, weight: 700, style: "normal" as const },
-        { name: "Noto Sans JP", data: fontRegular, weight: 400, style: "normal" as const },
+        { name: "Noto Sans JP", data: notoBlack, weight: 900, style: "normal" as const },
+        { name: "Noto Sans JP", data: notoBold, weight: 700, style: "normal" as const },
       ],
     },
   );
 
   const resvg = new Resvg(svg, {
-    fitTo: { mode: "width", value: 1200 },
+    fitTo: { mode: "width", value: 2400 },
   });
   const png = resvg.render().asPng();
 


### PR DESCRIPTION
## Summary
- ブログOGP画像を白カード+グリーングラデーション背景のデザインに全面刷新
- カテゴリーバッジの配色をブログページと統一
- 句読点・括弧で自然に改行する分割ロジックを実装（2行/3行対応、日英で閾値分離）
- タイトルにNoto Sans JP Black(900)、本文にBold(700)を使用
- QuitMateロゴを半透明ウォーターマークとして配置
- レンダリングを2x解像度(2400px)に変更

## Test plan
- [ ] `yarn build:lp` でOGP画像が正常に生成されること
- [ ] 日本語・英語の全記事でタイトルの改行が自然であること
- [ ] カテゴリーバッジの色がブログページと一致していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)