### PR TITLE
fix: LP の Google Play ストア URL を修正

### DIFF
--- a/apps/lp/src/config/themes.ts
+++ b/apps/lp/src/config/themes.ts
@@ -123,11 +123,11 @@ export const STORE_URLS: Record<string, { apple: string; google: string }> = {
   },
   alcohol: {
     apple: "https://apps.apple.com/jp/app/id6756336624",
-    google: "https://play.google.com/store/apps/details?id=com.quitmate.alcohol",
+    google: "https://play.google.com/store/apps/details?id=com.quitmate.kinshu",
   },
   kinshu: {
     apple: "https://apps.apple.com/jp/app/id6758752490",
-    google: "https://play.google.com/store/apps/details?id=com.quitmate.kinshu",
+    google: "https://play.google.com/store/apps/details?id=com.quitmate.alcohol",
   },
   porn: {
     apple: "https://apps.apple.com/jp/app/id6759315555",


### PR DESCRIPTION
## Summary
- 禁酒チャレンジ（alcohol）と禁酒メイト（kinshu）の Google Play URL が入れ替わっていたのを修正
- サイトマップの品質改善（ISR 追加、質の高いページに絞り込み）

## Test plan
- [ ] 禁酒チャレンジ LP（/challenge）の Android ストアリンクが正しいアプリに遷移するか確認
- [ ] 禁酒メイト LP の Android ストアリンクが正しいアプリに遷移するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)