### PR TITLE
style(lp): LPセクション全体のデザインリニューアル

### DIFF
--- a/apps/lp/src/components/sections/FAQ.astro
+++ b/apps/lp/src/components/sections/FAQ.astro
@@ -38,7 +38,7 @@ const faqSchema = {
 
     <div class="stagger-children flex flex-col gap-3">
       {items.map((item) => (
-        <details class="card group rounded-xl transition-all duration-200 open:shadow-md">
+        <details class="card group overflow-hidden rounded-2xl transition-all duration-200 open:shadow-md">
           <summary class="flex cursor-pointer items-center justify-between gap-4 px-6 py-5 text-base font-semibold md:text-lg [&::-webkit-details-marker]:hidden">
             <span>{item.question}</span>
             <svg

--- a/apps/lp/src/components/sections/Features.astro
+++ b/apps/lp/src/components/sections/Features.astro
@@ -31,37 +31,34 @@ const iconSvgs: Record<Feature["icon"], string> = {
       {title}
     </h2>
 
-    <div class="stagger-children flex flex-col gap-12 md:gap-16">
+    <div class="stagger-children grid grid-cols-1 gap-6 md:grid-cols-3 md:gap-8">
       {features.map((feature) => (
-        <div class="flex flex-col items-center gap-5 text-center md:flex-row md:gap-10 md:text-left">
+        <div class="card group p-8 text-center">
           <div
-            class="flex size-16 shrink-0 items-center justify-center rounded-2xl md:size-20"
-            style={`background: ${theme.accentColor}10`}
+            class="mx-auto mb-5 flex size-14 items-center justify-center rounded-2xl transition-transform duration-200 group-hover:scale-110 md:size-16"
+            style={`background: linear-gradient(135deg, ${theme.accentColor}, ${theme.accentColor}CC)`}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              width="28"
-              height="28"
+              width="26"
+              height="26"
               viewBox="0 0 24 24"
               fill="none"
-              stroke="currentColor"
+              stroke="white"
               stroke-width="1.5"
               stroke-linecap="round"
               stroke-linejoin="round"
-              style={`color: ${theme.accentColor}`}
             >
               <Fragment set:html={iconSvgs[feature.icon]} />
             </svg>
           </div>
 
-          <div>
-            <h3 class="mb-2 text-xl font-bold md:text-2xl">
-              {feature.title}
-            </h3>
-            <p class="text-base leading-relaxed text-[var(--sub-foreground)] md:text-lg">
-              {feature.description}
-            </p>
-          </div>
+          <h3 class="mb-3 text-lg font-bold md:text-xl">
+            {feature.title}
+          </h3>
+          <p class="text-sm leading-relaxed text-[var(--sub-foreground)] md:text-base">
+            {feature.description}
+          </p>
         </div>
       ))}
     </div>

--- a/apps/lp/src/components/sections/FinalCTA.astro
+++ b/apps/lp/src/components/sections/FinalCTA.astro
@@ -23,14 +23,18 @@ const closingText = closingRaw !== "final-cta.closing" ? closingRaw : "";
 ---
 
 <section
-  class="section-base text-center"
-  style={`background: ${theme.accentColor}1A`}
+  class="section-base relative overflow-hidden text-center"
+  style={`background: ${theme.lightText ? 'linear-gradient(135deg, #2a1035, #4a1a5f)' : `linear-gradient(160deg, ${theme.accentColor}14, ${theme.accentColor}22 50%, ${theme.accentColor}14)`}`}
 >
-  <div class="animate-on-scroll mx-auto max-w-2xl">
-    <h2 class="mb-5 md:mb-7">
+  <!-- 装飾ブロブ -->
+  <div class="pointer-events-none absolute -left-20 -top-20 size-96 rounded-full blur-3xl" style={`background: radial-gradient(circle, ${theme.accentColor}18 0%, transparent 70%)`} aria-hidden="true"></div>
+  <div class="pointer-events-none absolute -bottom-20 -right-20 size-80 rounded-full blur-3xl" style={`background: radial-gradient(circle, ${theme.accentColor}12 0%, transparent 70%)`} aria-hidden="true"></div>
+
+  <div class="animate-on-scroll relative z-10 mx-auto max-w-2xl">
+    <h2 class={`mb-5 md:mb-7 ${theme.lightText ? 'text-white' : ''}`}>
       {title}
     </h2>
-    <p class="mx-auto mb-12 max-w-lg text-base leading-relaxed text-[var(--sub-foreground)] md:text-lg">
+    <p class={`mx-auto mb-12 max-w-lg text-base leading-relaxed md:text-lg ${theme.lightText ? 'text-white/80' : 'text-[var(--sub-foreground)]'}`}>
       {description}
     </p>
 
@@ -46,7 +50,7 @@ const closingText = closingRaw !== "final-cta.closing" ? closingRaw : "";
     <!-- QRコード（デスクトップのみ） -->
     <div class="hidden items-center justify-center gap-10 md:flex">
       <div class="flex flex-col items-center gap-3">
-        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white p-2">
+        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white p-2 shadow-sm">
           <img
             src={`https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${encodeURIComponent(storeUrls.apple)}`}
             alt="App Store QR Code"
@@ -56,10 +60,10 @@ const closingText = closingRaw !== "final-cta.closing" ? closingRaw : "";
             loading="lazy"
           />
         </div>
-        <span class="text-xs font-medium text-[var(--sub-foreground)]">App Store</span>
+        <span class={`text-xs font-medium ${theme.lightText ? 'text-white/70' : 'text-[var(--sub-foreground)]'}`}>App Store</span>
       </div>
       <div class="flex flex-col items-center gap-3">
-        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white p-2">
+        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white p-2 shadow-sm">
           <img
             src={`https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${encodeURIComponent(storeUrls.google)}`}
             alt="Google Play QR Code"
@@ -69,12 +73,12 @@ const closingText = closingRaw !== "final-cta.closing" ? closingRaw : "";
             loading="lazy"
           />
         </div>
-        <span class="text-xs font-medium text-[var(--sub-foreground)]">Google Play</span>
+        <span class={`text-xs font-medium ${theme.lightText ? 'text-white/70' : 'text-[var(--sub-foreground)]'}`}>Google Play</span>
       </div>
     </div>
 
     {closingText && (
-      <p class="mt-8 text-sm text-[var(--sub-foreground)]">
+      <p class={`mt-8 text-sm ${theme.lightText ? 'text-white/70' : 'text-[var(--sub-foreground)]'}`}>
         {closingText}
       </p>
     )}

--- a/apps/lp/src/components/sections/GradientOrbsBackground.astro
+++ b/apps/lp/src/components/sections/GradientOrbsBackground.astro
@@ -13,9 +13,9 @@ const { accentColor = "#2E6C28" } = Astro.props;
 ---
 
 <div class="gradient-orbs" aria-hidden="true">
-  <div class="orb orb-1" style={`background: radial-gradient(circle, ${accentColor}30 0%, ${accentColor}08 50%, transparent 70%);`}></div>
-  <div class="orb orb-2" style={`background: radial-gradient(circle, ${accentColor}25 0%, ${accentColor}06 50%, transparent 70%);`}></div>
-  <div class="orb orb-3" style={`background: radial-gradient(circle, ${accentColor}20 0%, ${accentColor}04 50%, transparent 70%);`}></div>
+  <div class="orb orb-1" style={`background: radial-gradient(circle, ${accentColor}40 0%, ${accentColor}15 50%, transparent 70%);`}></div>
+  <div class="orb orb-2" style={`background: radial-gradient(circle, ${accentColor}35 0%, ${accentColor}10 50%, transparent 70%);`}></div>
+  <div class="orb orb-3" style={`background: radial-gradient(circle, ${accentColor}30 0%, ${accentColor}08 50%, transparent 70%);`}></div>
 </div>
 
 <style>
@@ -31,47 +31,48 @@ const { accentColor = "#2E6C28" } = Astro.props;
   .orb {
     position: absolute;
     border-radius: 50%;
+    filter: blur(60px);
   }
 
   .orb-1 {
-    width: 500px;
-    height: 500px;
-    top: -10%;
-    left: -5%;
+    width: 600px;
+    height: 600px;
+    top: -15%;
+    left: -8%;
   }
 
   .orb-2 {
-    width: 400px;
-    height: 400px;
-    bottom: -15%;
-    right: -5%;
+    width: 500px;
+    height: 500px;
+    bottom: -20%;
+    right: -8%;
   }
 
   .orb-3 {
-    width: 350px;
-    height: 350px;
-    top: 30%;
-    left: 50%;
+    width: 450px;
+    height: 450px;
+    top: 25%;
+    left: 45%;
   }
 
   @media (max-width: 767px) {
     .orb-1 {
-      width: 280px;
-      height: 280px;
+      width: 350px;
+      height: 350px;
       top: -15%;
       left: -20%;
     }
 
     .orb-2 {
-      width: 250px;
-      height: 250px;
+      width: 300px;
+      height: 300px;
       bottom: -10%;
       right: -15%;
     }
 
     .orb-3 {
-      width: 200px;
-      height: 200px;
+      width: 250px;
+      height: 250px;
       top: auto;
       bottom: 20%;
       left: -10%;

--- a/apps/lp/src/components/sections/Hero.astro
+++ b/apps/lp/src/components/sections/Hero.astro
@@ -38,7 +38,7 @@ const socialProofText = socialProofRaw !== "hero.social-proof" ? socialProofRaw 
     <!-- テキスト側 -->
     <div class="flex max-w-xl flex-1 flex-col items-center text-center md:items-start md:text-left">
       {socialProofText && (
-        <div class="mb-4 inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-medium shadow-sm md:mb-6">
+        <div class="reveal mb-4 inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white/90 px-4 py-2 text-sm font-medium shadow-sm backdrop-blur-sm md:mb-6">
           <span class="flex gap-0.5" role="img" aria-label="4.8 out of 5 stars">
             {[...Array(4)].map(() => (
               <svg class="size-4 text-amber-500" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
@@ -59,7 +59,7 @@ const socialProofText = socialProofRaw !== "hero.social-proof" ? socialProofRaw 
         </div>
       )}
 
-      <h1 class="mb-3 md:mb-7">
+      <h1 class="reveal reveal-delay-1 mb-3 md:mb-7">
         {eyebrow && (
           <span class="mb-2 block text-sm font-medium tracking-normal text-[var(--sub-foreground)]">
             {eyebrow}
@@ -68,7 +68,7 @@ const socialProofText = socialProofRaw !== "hero.social-proof" ? socialProofRaw 
         {title}
       </h1>
 
-      <p class="mb-3 text-lg leading-relaxed text-[var(--sub-foreground)] md:mb-4 md:text-xl">
+      <p class="reveal reveal-delay-2 mb-3 text-lg leading-relaxed text-[var(--sub-foreground)] md:mb-4 md:text-xl">
         {description}
       </p>
 
@@ -82,7 +82,7 @@ const socialProofText = socialProofRaw !== "hero.social-proof" ? socialProofRaw 
         </div>
       )}
 
-      <div class="flex flex-col items-center gap-4 md:items-start">
+      <div class="reveal reveal-delay-3 flex flex-col items-center gap-4 md:items-start">
         <div class="hidden md:block">
           <StoreBadges locale={locale} namespace={namespace} size="xl" eager />
         </div>
@@ -93,7 +93,7 @@ const socialProofText = socialProofRaw !== "hero.social-proof" ? socialProofRaw 
     </div>
 
     <!-- スクリーンショット -->
-    <div class="relative flex flex-1 items-center justify-center">
+    <div class="reveal reveal-delay-2 relative flex flex-1 items-center justify-center">
       <div class="phone-area">
         <div class="phone-frame">
           <div class="screenshot-viewer" data-screenshots={JSON.stringify(screenshots)}>

--- a/apps/lp/src/components/sections/HowItWorks.astro
+++ b/apps/lp/src/components/sections/HowItWorks.astro
@@ -22,14 +22,21 @@ const theme = getTheme(namespace);
       {title}
     </h2>
 
-    <div class="stagger-children grid grid-cols-1 gap-10 md:grid-cols-3 md:gap-12">
+    <div class="stagger-children relative grid grid-cols-1 gap-8 md:grid-cols-3 md:gap-6">
+      {/* 接続線（デスクトップのみ） */}
+      <div
+        class="pointer-events-none absolute left-[16%] right-[16%] top-[3.5rem] hidden h-0.5 md:block"
+        style={`background: linear-gradient(to right, transparent, ${theme.accentColor}60, ${theme.accentColor}60, transparent)`}
+        aria-hidden="true"
+      />
+
       {steps.map((step, index) => (
-        <div class="flex flex-col items-center text-center">
+        <div class="card relative flex flex-col items-center p-8 text-center">
           <div
-            class="mb-5 flex size-14 items-center justify-center rounded-full text-xl font-bold text-white"
+            class="mb-5 flex size-12 items-center justify-center rounded-xl text-lg font-bold text-white"
             style={`background: ${theme.accentColor}`}
           >
-            {index + 1}
+            {String(index + 1).padStart(2, '0')}
           </div>
           <h3 class="mb-2 text-lg font-bold md:text-xl">
             {step.title}

--- a/apps/lp/src/components/sections/Reviews.astro
+++ b/apps/lp/src/components/sections/Reviews.astro
@@ -28,7 +28,7 @@ const theme = getTheme(namespace);
     <!-- モバイル: 横スクロール / デスクトップ: 2x3グリッド -->
     <div class="reviews-scroll stagger-children -mx-[1.5rem] flex snap-x snap-mandatory gap-4 overflow-x-auto px-[calc(50vw-140px)] pb-4 md:mx-0 md:grid md:grid-cols-2 md:gap-6 md:overflow-visible md:px-0 md:pb-0 lg:grid-cols-3">
       {reviews.map(({ name, category, message }) => (
-        <div class="card flex w-[280px] shrink-0 snap-center flex-col p-6 md:w-auto">
+        <div class="card flex w-[280px] shrink-0 snap-center flex-col overflow-hidden p-6 md:w-auto" style={`border-top: 3px solid ${theme.accentColor}25`}>
           {/* ★評価 */}
           <div class="mb-3 flex gap-0.5" role="img" aria-label="5 out of 5 stars">
             {[...Array(5)].map(() => (

--- a/apps/lp/src/components/sections/SocialProof.astro
+++ b/apps/lp/src/components/sections/SocialProof.astro
@@ -26,9 +26,9 @@ const theme = getTheme(namespace);
 <section class="section-alt section-base">
   <div class="mx-auto max-w-6xl">
     <!-- 数字ハイライト -->
-    <div class="stagger-children grid grid-cols-2 gap-4 md:grid-cols-4 md:gap-8">
+    <div class="stagger-children grid grid-cols-2 gap-4 md:grid-cols-4 md:gap-6">
       {stats.map(({ value, label }) => (
-        <div class="text-center">
+        <div class="rounded-2xl p-5 text-center" style={`background: ${theme.accentColor}08`}>
           <div class="stat-number" style={`color: ${theme.accentColor}`}>
             {value}
           </div>
@@ -48,10 +48,10 @@ const theme = getTheme(namespace);
 
     <!-- レビューハイライト引用 -->
     {highlights.length > 0 && (
-      <div class="mt-14 grid gap-6 md:mt-20 md:grid-cols-2 md:gap-10">
+      <div class="mt-14 grid gap-6 md:mt-20 md:grid-cols-2 md:gap-8">
         {highlights.map(({ quote, author, category }) => (
-          <div class="animate-on-scroll">
-            <div class="text-4xl leading-none opacity-15" style={`color: ${theme.accentColor}`}>
+          <div class="animate-on-scroll rounded-2xl bg-white p-6 shadow-sm">
+            <div class="text-4xl leading-none opacity-20" style={`color: ${theme.accentColor}`}>
               &ldquo;
             </div>
             <p class="mt-1 text-lg font-medium leading-relaxed text-[var(--foreground)] md:text-xl">

--- a/apps/lp/src/styles/globals.css
+++ b/apps/lp/src/styles/globals.css
@@ -33,17 +33,22 @@
   --foreground: #1A1A1A;
   --sub-foreground: #6B6B6B;
   --section-alt: #FFFFFF;
-  --radius: 0.75rem;
+  --radius: 1rem;
 }
 
 html {
   /* スクロールバー有無で横位置がズレないように常に gutter を確保 */
   scrollbar-gutter: stable;
+  scroll-behavior: smooth;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
+  font-feature-settings: "palt";
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* ===== Typography ===== */
@@ -170,14 +175,15 @@ h3 {
 
 .card {
   background: #FFFFFF;
-  border-radius: var(--radius);
+  border-radius: var(--radius-lg);
   border: 1px solid rgba(0, 0, 0, 0.06);
-  transition: box-shadow 0.15s ease-out, transform 0.15s ease-out;
+  transition: box-shadow 0.2s ease-out, transform 0.2s ease-out, border-color 0.2s ease-out;
 }
 
 .card:hover {
-  box-shadow: 0 4px 16px -4px rgba(0, 0, 0, 0.08);
-  transform: translateY(-1px);
+  box-shadow: 0 8px 30px -8px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+  border-color: rgba(0, 0, 0, 0.1);
 }
 
 /* ===== Stat Number (Social Proof) ===== */
@@ -254,12 +260,36 @@ h3 {
 .stagger-children > *:nth-child(5) { animation-delay: 400ms; }
 .stagger-children > *:nth-child(6) { animation-delay: 500ms; }
 
+/* ===== Page-load Animation (Hero等) ===== */
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.reveal {
+  opacity: 0;
+  animation: fadeUp 0.8s ease-out forwards;
+}
+
+.reveal-delay-1 { animation-delay: 0.1s; }
+.reveal-delay-2 { animation-delay: 0.2s; }
+.reveal-delay-3 { animation-delay: 0.3s; }
+.reveal-delay-4 { animation-delay: 0.4s; }
+
 /* Respect reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .animate-on-scroll,
   .animate-fade-in,
   .animate-scale-in,
-  .stagger-children > * {
+  .stagger-children > *,
+  .reveal {
     animation: none;
     opacity: 1;
     transform: none;


### PR DESCRIPTION
## Summary
- naruiku LPのデザインクオリティに合わせてLPセクション全体をリデザイン
- globals.css: palt字詰め、font smoothing、角丸拡大、カードhover強化、fadeUpアニメーション追加
- Hero: fadeUpページロードアニメーション、背景オーブ拡大+blur強化
- Features: 縦リストから3カラムカードグリッドに変更、グラデーションアイコン
- HowItWorks: 各ステップをカード化、デスクトップで接続グラデーション線追加
- SocialProof: 統計値にアクセント背景カード、引用カードのスタイル改善
- Reviews: カードにアクセントカラーのトップボーダー追加
- FAQ: rounded-2xl + overflow-hidden
- FinalCTA: 装飾ブラーブロブ追加、背景のアクセント色調整
- GradientOrbsBackground: サイズ拡大+blur(60px)追加

## Test plan
- [ ] `yarn dev:lp` でローカル確認
- [ ] 各namespaceページ (default, alcohol, kinshu, porn, tobacco) の見た目確認
- [ ] モバイル/デスクトップ両方のレイアウト確認
- [ ] fadeUpアニメーションの動作確認
- [ ] `prefers-reduced-motion` でアニメーション無効化確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)