### PR TITLE
fix(lp): ブログ画像が表示されない問題を修正

### DIFF
--- a/apps/lp/public/_redirects
+++ b/apps/lp/public/_redirects
@@ -18,6 +18,7 @@
 /jp/* /ja/:splat 301
 /jp /ja/ 301
 
-# ロケールなしブログ → /en/blog/
+# ロケールなしブログ → /en/blog/（画像パスは除外）
+/blog/images/* /blog/images/:splat 200
 /blog/* /en/blog/:splat 301
 /blog /en/blog/ 301


### PR DESCRIPTION
## Summary
- `_redirects` の `/blog/*` ルールが `/blog/images/*` もキャッチし、画像が `/en/blog/images/*` に301リダイレクトされて404になっていた
- `/blog/images/*` を200リライトで先にマッチさせることで、静的ファイルとして正しく配信されるように修正

## Test plan
- [ ] 本番ブログページで画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)