### PR TITLE
feat(web): UI/UX全面改善 + 未ログインCTA導線

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -137,6 +137,12 @@
     "title": "Addiction Recovery SNS QuitMate",
     "message": "To read more stories, download the app"
   },
+  "feed-cta": {
+    "title": "Quit together with others",
+    "description": "Post your story and support others on the app",
+    "downloadApp": "Download the App",
+    "signUp": "Create Account"
+  },
   "habit-register": {
     "title": "Register Habit to Quit",
     "description": "Register a new habit",
@@ -190,6 +196,7 @@
     "habits": "Habits",
     "articles": "Articles",
     "blog": "Blog",
+    "learn": "Textbook",
     "app": "App",
     "habitCategories": "Habit Categories",
     "myCommunity": "My Community",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -331,7 +331,9 @@
     "article-title": "Support articles you relate to or want to cheer on.",
     "article-description": "Create an account to support articles.",
     "login": "Log in",
-    "sign-up": "Create account"
+    "login-prefix": "Already have an account? ",
+    "sign-up": "Create account",
+    "download-app": "Download the App"
   },
   "comment-form": {
     "placeholder": "Add a comment...",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -141,7 +141,11 @@
     "title": "Quit together with others",
     "description": "Post your story and support others on the app",
     "downloadApp": "Download the App",
-    "signUp": "Create Account"
+    "signUp": "Create Account",
+    "loginLink": {
+      "prefix": "Already have an account? ",
+      "action": "Log in"
+    }
   },
   "habit-register": {
     "title": "Register Habit to Quit",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -97,6 +97,12 @@
     "title": "依存克服SNS QuitMate",
     "message": "もっと多くのストーリーを読むには\nアプリをダウンロードしよう"
   },
+  "feed-cta": {
+    "title": "一緒に依存を克服しよう",
+    "description": "アプリで投稿したり、仲間を応援したりできます",
+    "downloadApp": "アプリをダウンロード",
+    "signUp": "アカウント作成"
+  },
   "habit-register": {
     "title": "やめる習慣を登録",
     "description": "新しい習慣を登録します",
@@ -168,6 +174,7 @@
     "habits": "習慣",
     "articles": "記事",
     "blog": "ブログ",
+    "learn": "教科書",
     "app": "アプリ",
     "habitCategories": "習慣カテゴリー",
     "myCommunity": "マイコミュニティ",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -309,7 +309,9 @@
     "article-title": "共感した記事、応援したい記事に「応援」しましょう。",
     "article-description": "アカウントを作成すると、記事を「応援」できます。",
     "login": "ログイン",
-    "sign-up": "アカウント作成"
+    "login-prefix": "すでにアカウントをお持ちの方は",
+    "sign-up": "アカウント作成",
+    "download-app": "アプリをダウンロード"
   },
   "comment-form": {
     "placeholder": "コメントを追加...",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -101,7 +101,11 @@
     "title": "一緒に依存を克服しよう",
     "description": "アプリで投稿したり、仲間を応援したりできます",
     "downloadApp": "アプリをダウンロード",
-    "signUp": "アカウント作成"
+    "signUp": "アカウント作成",
+    "loginLink": {
+      "prefix": "すでにアカウントをお持ちの方は",
+      "action": "ログイン"
+    }
   },
   "habit-register": {
     "title": "やめる習慣を登録",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "react-intersection-observer": "^10.0.3",
     "react-markdown": "^10.1.0",
     "sharp": "^0.34.5",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/apps/web/src/app/(main)/loading.tsx
+++ b/apps/web/src/app/(main)/loading.tsx
@@ -1,4 +1,4 @@
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { StoryListSkeleton } from "@/features/stories/ui/story-tile-skeleton";
 
 /**
  * サイドバー付きページ用のローディング
@@ -6,9 +6,5 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner";
  * このローディングはコンテンツ部分のみに適用される
  */
 export default function Loading() {
-  return (
-    <div className="flex flex-1 items-center justify-center py-20">
-      <LoadingSpinner />
-    </div>
-  );
+  return <StoryListSkeleton />;
 }

--- a/apps/web/src/app/(main)/stories/create/page.tsx
+++ b/apps/web/src/app/(main)/stories/create/page.tsx
@@ -27,7 +27,7 @@ export default async function CreateStoryPage() {
   return (
     <>
       <Header title="Create New Story" currentUserProfile={currentUserProfile} />
-      <div className="container mx-auto max-w-2xl px-4 py-8">
+      <div className="container mx-auto max-w-[600px] px-4 py-8">
         <StoryCreateForm habits={habits} />
       </div>
     </>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -30,6 +30,14 @@
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
+  --animate-like-bounce: like-bounce 0.35s ease-out;
+}
+
+@keyframes like-bounce {
+  0% { transform: scale(1); }
+  30% { transform: scale(1.35); }
+  60% { transform: scale(0.9); }
+  100% { transform: scale(1); }
 }
 
 :root {
@@ -39,8 +47,8 @@
   --card-foreground: 0 0% 3.9%;
   --popover: 0 0% 100%;
   --popover-foreground: 0 0% 3.9%;
-  --primary: 0 0% 9%;
-  --primary-foreground: 0 0% 98%;
+  --primary: 115 46% 29%;
+  --primary-foreground: 0 0% 100%;
   --secondary: 0 0% 96.1%;
   --secondary-foreground: 0 0% 9%;
   --muted: 0 0% 96.1%;
@@ -51,14 +59,13 @@
   --destructive-foreground: 0 0% 98%;
   --border: 0 0% 89.8%;
   --input: 0 0% 89.8%;
-  --ring: 0 0% 3.9%;
+  --ring: 115 46% 29%;
   --radius: 0.5rem;
   --chart-1: 12 76% 61%;
   --chart-2: 173 58% 39%;
   --chart-3: 197 37% 24%;
   --chart-4: 43 74% 66%;
   --chart-5: 27 87% 67%;
-  --color-primary-rgb: 46 108 40; /* #2E6C28を RGB値に変換 */
 }
 
 .dark {
@@ -68,7 +75,7 @@
   --card-foreground: 0 0% 98%;
   --popover: 0 0% 3.9%;
   --popover-foreground: 0 0% 98%;
-  --primary: 0 0% 98%;
+  --primary: 119 59% 66%;
   --primary-foreground: 0 0% 9%;
   --secondary: 0 0% 14.9%;
   --secondary-foreground: 0 0% 98%;
@@ -80,13 +87,12 @@
   --destructive-foreground: 0 0% 98%;
   --border: 0 0% 14.9%;
   --input: 0 0% 14.9%;
-  --ring: 0 0% 83.1%;
+  --ring: 119 59% 66%;
   --chart-1: 220 70% 50%;
   --chart-2: 160 60% 45%;
   --chart-3: 30 80% 55%;
   --chart-4: 280 65% 60%;
   --chart-5: 340 75% 55%;
-  --color-primary-rgb: 120 220 119; /* #78DC77を RGB値に変換 */
 }
 
 * {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { Geist } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { ThemeProvider } from "next-themes";
 
+import { Toaster } from "sonner";
+
 import { Footer } from "@/components/layout/footer";
 import { SmartBanner } from "@/components/ui/smart-banner";
 import { QueryProvider } from "@/app/providers";
@@ -116,6 +118,7 @@ export default async function RootLayout({
                 profile={currentUserProfile}
               >
                 <HabitsProvider habits={habits}>
+                  <Toaster position="bottom-center" richColors />
                   <main className="flex min-h-screen flex-col items-center">
                     <div className="flex w-full flex-1 flex-col items-center">
                       <div className="flex w-full max-w-5xl">

--- a/apps/web/src/components/layout/mobile-bottom-nav.tsx
+++ b/apps/web/src/components/layout/mobile-bottom-nav.tsx
@@ -5,6 +5,9 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 
+import { useHabits } from "@/features/habits/providers/habits-provider";
+import { getFirstHabitCommunityUrl } from "./sidebar-utils";
+
 type MobileBottomNavProps = {
   currentUserUsername?: string | null;
 };
@@ -13,8 +16,8 @@ export function MobileBottomNav({ currentUserUsername }: MobileBottomNavProps) {
   const pathname = usePathname();
   const t = useTranslations("sidebar");
 
-  // ホームのパス（ルートにリダイレクトするとサーバー側で適切なパスにリダイレクトされる）
-  const homePath = "/";
+  const habits = useHabits();
+  const homePath = getFirstHabitCommunityUrl(habits);
   const habitsPath = "/habits";
 
   // ホームはルートパスまたはコミュニティタイムラインページでアクティブ
@@ -32,7 +35,7 @@ export function MobileBottomNav({ currentUserUsername }: MobileBottomNavProps) {
           href={homePath}
           aria-current={isHomeActive ? "page" : undefined}
           className={`flex flex-col items-center justify-center gap-0.5 px-3 py-1.5 text-[10px] font-medium transition-colors ${
-            isHomeActive ? "text-primary-light dark:text-primary-dark" : "text-muted-foreground"
+            isHomeActive ? "text-primary" : "text-muted-foreground"
           }`}
         >
           <Home className={`size-5 ${isHomeActive ? "fill-current" : ""}`} />
@@ -45,7 +48,7 @@ export function MobileBottomNav({ currentUserUsername }: MobileBottomNavProps) {
             href={habitsPath}
             aria-current={isHabitsActive ? "page" : undefined}
             className={`flex flex-col items-center justify-center gap-0.5 px-3 py-1.5 text-[10px] font-medium transition-colors ${
-              isHabitsActive ? "text-primary-light dark:text-primary-dark" : "text-muted-foreground"
+              isHabitsActive ? "text-primary" : "text-muted-foreground"
             }`}
           >
             <ClipboardCheck className={`size-5 ${isHabitsActive ? "fill-current" : ""}`} />

--- a/apps/web/src/components/layout/mobile-sidebar-content.tsx
+++ b/apps/web/src/components/layout/mobile-sidebar-content.tsx
@@ -6,6 +6,8 @@ import {
   ChevronDown,
   ChevronRight,
   Compass,
+  GraduationCap,
+  Newspaper,
   Settings,
   Smartphone,
   Users,
@@ -16,6 +18,7 @@ import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useState } from "react";
 
 import { CATEGORY_ICONS, HABIT_CATEGORIES, getCategoryUrl } from "@/lib/categories";
+import { EXTERNAL_URLS } from "@/lib/urls";
 import { cn } from "@/lib/utils";
 import { useHabits } from "@/features/habits/providers/habits-provider";
 import {
@@ -36,6 +39,7 @@ export function MobileSidebarContent({
   const pathname = usePathname();
   const t = useTranslations("sidebar");
   const tCategory = useTranslations("categories");
+  const tConfig = useTranslations("config");
   const tAppDownload = useTranslations("app-download-dialog");
   const [isOtherCommunityOpen, setIsOtherCommunityOpen] = useState(false);
 
@@ -205,6 +209,24 @@ export function MobileSidebarContent({
           label={t("articles")}
           href="/articles"
           active={pathname === "/articles"}
+          showLabel
+          onClick={handleLinkClick}
+        />
+        {/* ブログ（外部サイト） */}
+        <SidebarIcon
+          icon={Newspaper}
+          label={t("blog")}
+          href={`${EXTERNAL_URLS.LP}/${tConfig("language-code")}/blog`}
+          active={false}
+          showLabel
+          onClick={handleLinkClick}
+        />
+        {/* 教科書（外部サイト） */}
+        <SidebarIcon
+          icon={GraduationCap}
+          label={t("learn")}
+          href={`${EXTERNAL_URLS.LP}/${tConfig("language-code")}/learn`}
+          active={false}
           showLabel
           onClick={handleLinkClick}
         />

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Smartphone,
   UserRound,
   Newspaper,
+  GraduationCap,
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -88,12 +89,14 @@ export function SidebarContent({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const homeHref = getFirstHabitCommunityUrl(habits) || getCategoryUrl("All" as HabitCategoryName);
+
   return (
     <div className="flex h-full flex-col">
       {!skipLogo && (
         <div className={`mb-6 shrink-0 py-3 ${compact ? "flex justify-center" : "px-4"}`}>
           <Link
-            href="/"
+            href={homeHref}
             className={`flex items-end gap-1 ${compact ? "justify-center" : ""}`}
             onClick={handleLinkClick}
           >
@@ -276,7 +279,7 @@ export function SidebarContent({
               onClick={() => setIsOtherCommunityOpen(!isOtherCommunityOpen)}
               className={`flex items-center rounded-md py-2 transition-colors ${
                 !compact ? "w-full justify-between gap-4 px-4" : "w-full justify-center px-2"
-              } text-muted-foreground hover:bg-primary-light/10 hover:text-primary-light dark:hover:bg-primary-dark/10 dark:hover:text-primary-dark hover:font-medium`}
+              } text-muted-foreground hover:bg-primary/10 hover:text-primary hover:font-medium`}
               title={!compact ? t("otherCommunity") : undefined}
             >
               {compact ? (
@@ -335,6 +338,15 @@ export function SidebarContent({
           icon={Newspaper}
           label={t("blog")}
           href={`${EXTERNAL_URLS.LP}/${tConfig("language-code")}/blog`}
+          active={false}
+          showLabel={!compact}
+          onClick={handleLinkClick}
+        />
+        {/* 教科書（外部サイト） */}
+        <SidebarIcon
+          icon={GraduationCap}
+          label={t("learn")}
+          href={`${EXTERNAL_URLS.LP}/${tConfig("language-code")}/learn`}
           active={false}
           showLabel={!compact}
           onClick={handleLinkClick}

--- a/apps/web/src/components/ui/loading-spinner.tsx
+++ b/apps/web/src/components/ui/loading-spinner.tsx
@@ -5,7 +5,7 @@ type LoadingSpinnerProps = {
 export const LoadingSpinner = ({ fullHeight = false }: LoadingSpinnerProps) => {
   return (
     <div className={`flex items-center justify-center ${fullHeight ? "min-h-screen" : ""}`}>
-      <div className="size-12 animate-spin rounded-full border-4 border-gray-200 border-t-gray-900 dark:border-gray-700 dark:border-t-gray-100"></div>
+      <div className="border-muted-foreground/20 border-t-foreground size-12 animate-spin rounded-full border-4"></div>
     </div>
   );
 };

--- a/apps/web/src/components/ui/login-prompt-dialog.tsx
+++ b/apps/web/src/components/ui/login-prompt-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Heart } from "lucide-react";
+import { AppDownloadDialogTrigger } from "@quitmate/ui";
+import { Download, Heart } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { ReactNode, useState } from "react";
@@ -24,6 +25,7 @@ type LoginPromptDialogProps = {
 export function LoginPromptDialog({ children, className, type = "story" }: LoginPromptDialogProps) {
   const [open, setOpen] = useState(false);
   const t = useTranslations("login-prompt");
+  const tAppDownload = useTranslations("app-download-dialog");
 
   const title = type === "article" ? t("article-title") : t("story-title");
   const description = type === "article" ? t("article-description") : t("story-description");
@@ -40,12 +42,27 @@ export function LoginPromptDialog({ children, className, type = "story" }: Login
           <DialogDescription className="text-center">{description}</DialogDescription>
         </DialogHeader>
         <div className="mt-4 flex flex-col gap-3">
+          <AppDownloadDialogTrigger
+            title={tAppDownload("title")}
+            description={tAppDownload("description")}
+            qrCodeLabel={tAppDownload("qrCodeLabel")}
+            qrCodeAlt={tAppDownload("qrCodeAlt")}
+            storeLabel={tAppDownload("storeLabel")}
+          >
+            <Button className="w-full cursor-pointer">
+              <Download className="mr-2 size-4" />
+              {t("download-app")}
+            </Button>
+          </AppDownloadDialogTrigger>
           <Button asChild className="w-full" variant="outline">
-            <Link href="/auth/login">{t("login")}</Link>
-          </Button>
-          <Button asChild className="w-full">
             <Link href="/auth/sign-up">{t("sign-up")}</Link>
           </Button>
+          <p className="text-muted-foreground text-center text-xs">
+            {t("login-prefix")}
+            <Link href="/auth/login" className="text-primary hover:underline">
+              {t("login")}
+            </Link>
+          </p>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,7 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("bg-muted animate-pulse rounded-md", className)} {...props} />;
+}
+
+export { Skeleton };

--- a/apps/web/src/features/articles/ui/article-comment-tile.tsx
+++ b/apps/web/src/features/articles/ui/article-comment-tile.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 import { MoreHorizontal, Trash2, Flag } from "lucide-react";
 
 import { ArticleCommentTileDto } from "@/lib/types";
@@ -36,7 +37,6 @@ export function ArticleCommentTile({ comment, isLoggedIn = false, currentUserId 
   const tReport = useTranslations("report");
   const [menuOpen, setMenuOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
-  const [showDeleteSuccess, setShowDeleteSuccess] = useState(false);
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
 
   const isMyComment = currentUserId === comment.user_id;
@@ -48,8 +48,7 @@ export function ArticleCommentTile({ comment, isLoggedIn = false, currentUserId 
     startTransition(async () => {
       const result = await deleteArticleComment(comment.id);
       if (result.success) {
-        setShowDeleteSuccess(true);
-        setTimeout(() => setShowDeleteSuccess(false), 3000);
+        toast.success(tDelete("success"));
         router.refresh();
       } else {
         // エラー時はコンソールに出力（将来的にスナックバーで表示する場合は翻訳を使用）
@@ -130,7 +129,7 @@ export function ArticleCommentTile({ comment, isLoggedIn = false, currentUserId 
             </DropdownMenu>
           )}
         </div>
-        <p className="text-foreground whitespace-pre-wrap text-sm">{comment.content}</p>
+        <p className="text-foreground text-sm whitespace-pre-wrap">{comment.content}</p>
 
         {/* Like button */}
         <div className="text-muted-foreground mt-1 flex items-center gap-1">
@@ -149,13 +148,6 @@ export function ArticleCommentTile({ comment, isLoggedIn = false, currentUserId 
           </AppDownloadDialogTrigger>
         </div>
       </div>
-
-      {/* 削除成功スナックバー */}
-      {showDeleteSuccess && (
-        <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-green-600 px-4 py-2 text-white shadow-lg">
-          {tDelete("success")}
-        </div>
-      )}
 
       {/* 報告ダイアログ */}
       {!isMyComment && (

--- a/apps/web/src/features/articles/ui/article-content.tsx
+++ b/apps/web/src/features/articles/ui/article-content.tsx
@@ -9,6 +9,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { MoreHorizontal, Trash2, Flag } from "lucide-react";
+import { toast } from "sonner";
 
 import { MarkdownRenderer } from "@/lib/markdown-render";
 import type { ArticleTileDto, ArticleCommentTileDto } from "@/lib/types";
@@ -57,7 +58,6 @@ export function ArticleContent({
   const [likesCount, setLikesCount] = useState(article.article_likes[0]?.count ?? 0);
   const [isPending, startTransition] = useTransition();
   const [menuOpen, setMenuOpen] = useState(false);
-  const [showDeleteSuccess, setShowDeleteSuccess] = useState(false);
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
 
   const isMyArticle = currentUserId === article.user_id;
@@ -87,8 +87,7 @@ export function ArticleContent({
     startTransition(async () => {
       const result = await deleteArticle(article.id);
       if (result.success) {
-        setShowDeleteSuccess(true);
-        setTimeout(() => setShowDeleteSuccess(false), 3000);
+        toast.success(tDelete("success"));
         router.push(`/${article.profiles.user_name}`);
       } else {
         // エラー時はコンソールに出力（将来的にスナックバーで表示する場合は翻訳を使用）
@@ -120,37 +119,32 @@ export function ArticleContent({
         refreshingLabel={tPull("refreshing")}
       />
       <main className="w-full p-3 sm:p-5">
-        <div className="mx-auto w-full max-w-2xl bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+        <div className="text-foreground mx-auto w-full max-w-[600px]">
           {/* Article header */}
           <div className="mb-8">
-            <h1 className="mb-6 text-2xl font-bold text-gray-900 sm:hidden dark:text-white">
-              {article.title}
-            </h1>
+            <h1 className="text-foreground mb-6 text-2xl font-bold sm:hidden">{article.title}</h1>
             <div className="mb-4 flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <CategoryTag
                   category={article.habit_categories?.habit_category_name ?? "General"}
                   customHabitName={article.custom_habit_name}
                 />
-                <span className="text-sm text-gray-500 dark:text-gray-400">{createdAt}</span>
+                <span className="text-muted-foreground text-sm">{createdAt}</span>
               </div>
 
               <div className="flex items-center gap-4">
                 {isLoggedIn ? (
                   <button
                     onClick={handleLike}
-                    disabled={isPending}
-                    className="flex cursor-pointer items-center gap-1 transition-colors disabled:opacity-50"
+                    className="flex cursor-pointer items-center gap-1 transition-colors"
                   >
                     <ArticleLikeIcon
                       className={`size-5 transition-colors ${
-                        isLiked
-                          ? "fill-green-600 text-green-600"
-                          : "text-gray-500 dark:text-gray-400"
+                        isLiked ? "fill-red-500 text-red-500" : "text-muted-foreground"
                       }`}
                     />
                     <span
-                      className={`text-sm ${isLiked ? "text-green-600" : "text-gray-500 dark:text-gray-400"}`}
+                      className={`text-sm ${isLiked ? "text-red-500" : "text-muted-foreground"}`}
                     >
                       {likesCount}
                     </span>
@@ -158,8 +152,8 @@ export function ArticleContent({
                 ) : (
                   <LoginPromptDialog className="cursor-pointer" type="article">
                     <div className="flex items-center gap-1">
-                      <ArticleLikeIcon className="size-5 text-gray-500 dark:text-gray-400" />
-                      <span className="text-sm text-gray-500 dark:text-gray-400">{likesCount}</span>
+                      <ArticleLikeIcon className="text-muted-foreground size-5" />
+                      <span className="text-muted-foreground text-sm">{likesCount}</span>
                     </div>
                   </LoginPromptDialog>
                 )}
@@ -216,13 +210,9 @@ export function ArticleContent({
               />
               <div>
                 <Link href={`/${article.profiles.user_name}`} className="hover:underline">
-                  <p className="font-medium text-gray-900 dark:text-white">
-                    {article.profiles.display_name}
-                  </p>
+                  <p className="text-foreground font-medium">{article.profiles.display_name}</p>
                 </Link>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  @{article.profiles.user_name}
-                </p>
+                <p className="text-muted-foreground text-xs">@{article.profiles.user_name}</p>
               </div>
             </div>
           </div>
@@ -237,33 +227,28 @@ export function ArticleContent({
                 {isLoggedIn ? (
                   <button
                     onClick={handleLike}
-                    disabled={isPending}
-                    className="flex cursor-pointer items-center gap-2 transition-colors disabled:opacity-50"
+                    className="flex cursor-pointer items-center gap-2 transition-colors"
                   >
                     <ArticleLikeIcon
                       className={`size-5 transition-colors ${
-                        isLiked
-                          ? "fill-green-600 text-green-600"
-                          : "text-gray-500 dark:text-gray-400"
+                        isLiked ? "fill-red-500 text-red-500" : "text-muted-foreground"
                       }`}
                     />
-                    <span
-                      className={isLiked ? "text-green-600" : "text-gray-700 dark:text-gray-300"}
-                    >
+                    <span className={isLiked ? "text-red-500" : "text-muted-foreground"}>
                       {likesCount}
                     </span>
                   </button>
                 ) : (
                   <LoginPromptDialog className="cursor-pointer" type="article">
                     <div className="flex items-center gap-2">
-                      <ArticleLikeIcon className="size-5 text-gray-500 dark:text-gray-400" />
-                      <span className="text-gray-700 dark:text-gray-300">{likesCount}</span>
+                      <ArticleLikeIcon className="text-muted-foreground size-5" />
+                      <span className="text-muted-foreground">{likesCount}</span>
                     </div>
                   </LoginPromptDialog>
                 )}
                 <div className="flex items-center gap-2">
-                  <CommentIcon className="size-5 text-gray-500 dark:text-gray-400" />
-                  <span className="text-gray-700 dark:text-gray-300">
+                  <CommentIcon className="text-muted-foreground size-5" />
+                  <span className="text-muted-foreground">
                     {article.article_comments[0]?.count ?? 0}
                   </span>
                 </div>
@@ -279,14 +264,14 @@ export function ArticleContent({
           </div>
 
           <div className="mt-8">
-            <h2 className="mb-4 text-lg font-bold text-gray-900 dark:text-white">
+            <h2 className="text-foreground mb-4 text-lg font-bold">
               Comments ({article.article_comments[0]?.count ?? 0})
             </h2>
 
             {/* コメントフォーム（ログイン時のみ表示） */}
             {isLoggedIn && <ArticleCommentForm articleId={article.id} />}
 
-            <div className="space-y-2 border-t border-gray-200 dark:border-gray-800">
+            <div className="border-border space-y-2 border-t">
               {comments && comments.length > 0 ? (
                 comments.map((comment) => (
                   <ArticleCommentTile
@@ -297,7 +282,7 @@ export function ArticleContent({
                   />
                 ))
               ) : (
-                <p className="py-4 text-center text-gray-500 dark:text-gray-400">No comments yet</p>
+                <p className="text-muted-foreground py-4 text-center">No comments yet</p>
               )}
             </div>
           </div>
@@ -306,13 +291,6 @@ export function ArticleContent({
             customMessage={`${t("preFollowMessage")}${article.profiles.display_name}${t("postFollowMessage")}`}
           />
         </div>
-
-        {/* 削除成功スナックバー */}
-        {showDeleteSuccess && (
-          <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-green-600 px-4 py-2 text-white shadow-lg">
-            {tDelete("success")}
-          </div>
-        )}
 
         {/* 報告ダイアログ */}
         {!isMyArticle && (

--- a/apps/web/src/features/articles/ui/article-list-content.tsx
+++ b/apps/web/src/features/articles/ui/article-list-content.tsx
@@ -39,7 +39,7 @@ export function ArticleListContent({ initialArticles, isLoggedIn }: ArticleListC
         idleLabel={tPull("pullToRefresh")}
         refreshingLabel={tPull("refreshing")}
       />
-      <div className="mx-auto max-w-2xl space-y-2">
+      <div className="mx-auto max-w-[600px] space-y-2">
         {articles.map((article) => (
           <ArticleTile key={article.id} article={article} isLoggedIn={isLoggedIn} />
         ))}

--- a/apps/web/src/features/articles/ui/article-list-infinite-by-user.tsx
+++ b/apps/web/src/features/articles/ui/article-list-infinite-by-user.tsx
@@ -98,7 +98,7 @@ export function ArticleListInfiniteByUser({ userId, isLoggedIn }: Props) {
   }
 
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto max-w-[600px]">
       {articles.map((article) => (
         <ArticleTile key={article.id} article={article} isLoggedIn={isLoggedIn} />
       ))}

--- a/apps/web/src/features/articles/ui/article-tile.tsx
+++ b/apps/web/src/features/articles/ui/article-tile.tsx
@@ -1,20 +1,35 @@
 "use client";
 
-import { ArticleLikeIcon, CommentIcon, DefaultAvatar } from "@quitmate/ui";
+import { ArticleLikeIcon, CommentIcon } from "@quitmate/ui";
 import { format } from "date-fns";
 import { enUS } from "date-fns/locale";
 import { toZonedTime } from "date-fns-tz";
-import Image from "next/image";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 
 import { ArticleTileDto } from "@/lib/types";
 
 import { LoginPromptDialog } from "@/components/ui/login-prompt-dialog";
 import { CategoryTag } from "@/features/common/ui/category-tag";
+import { UserAvatar } from "@/features/profiles/ui/user-avatar";
 import { toggleArticleLike } from "@/features/articles/data/actions";
+
+/** Markdownの記法を除去してプレーンテキストを取得 */
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/#{1,6}\s+/g, "")
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1")
+    .replace(/`(.+?)`/g, "$1")
+    .replace(/\[(.+?)\]\(.+?\)/g, "$1")
+    .replace(/!\[.*?\]\(.+?\)/g, "")
+    .replace(/^[-*+]\s+/gm, "")
+    .replace(/^\d+\.\s+/gm, "")
+    .replace(/^>\s+/gm, "")
+    .replace(/---+/g, "")
+    .replace(/\n{2,}/g, " ")
+    .trim();
+}
 
 type Props = {
   article: ArticleTileDto;
@@ -22,137 +37,105 @@ type Props = {
 };
 
 export function ArticleTile({ article, isLoggedIn = false }: Props) {
-  // いいね状態の管理（楽観的更新）
+  const router = useRouter();
   const [isLiked, setIsLiked] = useState(article.isLikedByMe ?? false);
   const [likesCount, setLikesCount] = useState(article.article_likes[0]?.count ?? 0);
-  const [isPending, startTransition] = useTransition();
+  const [, startTransition] = useTransition();
 
   const handleLike = (e: React.MouseEvent) => {
-    e.preventDefault();
     e.stopPropagation();
 
     const shouldLike = !isLiked;
-
-    // 楽観的更新（即座にUI更新）
     setIsLiked(shouldLike);
     setLikesCount((prev) => (shouldLike ? prev + 1 : prev - 1));
 
-    // バックグラウンドでDB保存
     startTransition(async () => {
       const result = await toggleArticleLike(article.id, shouldLike);
       if (!result.success) {
-        // 失敗時はロールバック
         setIsLiked(!shouldLike);
         setLikesCount((prev) => (shouldLike ? prev - 1 : prev + 1));
       }
     });
   };
-  // Convert article date to Tokyo time
+
   const articleDate = toZonedTime(new Date(article.created_at), "Asia/Tokyo");
   const currentYear = new Date().getFullYear();
   const articleYear = articleDate.getFullYear();
-
-  // If current year, don't display year; otherwise include year
   const dateFormat = articleYear === currentYear ? "M/d H:mm" : "yyyy/M/d H:mm";
-  const createdAt = format(articleDate, dateFormat, {
-    locale: enUS,
-  });
+  const createdAt = format(articleDate, dateFormat, { locale: enUS });
 
   const articleUrl = `/${article.profiles.user_name}/articles/${article.id}`;
+  const excerpt = stripMarkdown(article.content).slice(0, 160);
+
+  const handleClick = () => {
+    router.push(articleUrl);
+  };
 
   return (
-    <div className="overflow-hidden rounded-lg border border-gray-200 shadow-sm transition-all hover:shadow-md dark:border-gray-700">
-      <div className="p-3 md:p-4">
-        <Link href={articleUrl} className="block">
-          {/* Title */}
-          <h2 className="mb-1.5 line-clamp-2 text-lg font-bold text-gray-900 md:mb-1 md:text-xl dark:text-white">
-            {article.title}
-          </h2>
+    <div
+      className="border-border cursor-pointer overflow-hidden rounded-lg border shadow-sm transition-all hover:shadow-md"
+      onClick={handleClick}
+    >
+      <div className="p-4 md:p-5">
+        {/* タイトル */}
+        <h2 className="text-foreground mb-2 line-clamp-2 text-lg font-bold md:text-xl">
+          {article.title}
+        </h2>
 
-          {/* Category tag and date */}
-          <div className="mb-1.5 flex items-center justify-between md:mb-1">
-            <CategoryTag
-              category={article.habit_categories?.habit_category_name ?? "General"}
-              customHabitName={article.custom_habit_name}
-            />
-            <span className="text-xs text-gray-500 dark:text-gray-400">{createdAt}</span>
-          </div>
-        </Link>
-
-        {/* Article description (Markdown) */}
-        <div className="prose-sm dark:prose-invert prose-headings:my-0 prose-p:my-0 prose-li:my-0 mb-2.5 line-clamp-3 text-gray-700 md:mb-4 dark:text-gray-300">
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={{
-              a: ({ href, children, ...props }) => (
-                <a
-                  href={href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-medium text-green-800 no-underline hover:underline dark:text-green-400"
-                  {...props}
-                >
-                  {children}
-                </a>
-              ),
-            }}
-          >
-            {article.content}
-          </ReactMarkdown>
+        {/* カテゴリバッジ + 日付 */}
+        <div className="mb-2 flex items-center justify-between">
+          <CategoryTag
+            category={article.habit_categories?.habit_category_name ?? "General"}
+            customHabitName={article.custom_habit_name}
+          />
+          <span className="text-muted-foreground text-xs">{createdAt}</span>
         </div>
 
-        {/* Actions and user info */}
+        {/* プレーンテキスト抜粋 */}
+        <p className="text-muted-foreground mb-3 line-clamp-3 text-sm leading-relaxed">{excerpt}</p>
+
+        {/* アクション + 著者情報 */}
         <div className="flex items-center justify-between">
-          {/* Comments and likes */}
-          <div className="flex gap-4 text-gray-500 md:gap-6 dark:text-gray-400">
+          <div className="text-muted-foreground flex gap-4">
             <div className="flex items-center gap-1">
-              <CommentIcon className="size-4 md:size-5" />
-              <span className="text-xs md:text-sm">{article.article_comments[0]?.count ?? 0}</span>
+              <CommentIcon className="size-4" />
+              <span className="text-xs">{article.article_comments[0]?.count ?? 0}</span>
             </div>
-            {isLoggedIn ? (
-              <button
-                onClick={handleLike}
-                disabled={isPending}
-                className="flex cursor-pointer items-center gap-1 transition-colors disabled:opacity-50"
-              >
-                <ArticleLikeIcon
-                  className={`size-4 transition-colors md:size-5 ${isLiked ? "fill-green-600 text-green-600" : ""}`}
-                />
-                <span className={`text-xs md:text-sm ${isLiked ? "text-green-600" : ""}`}>
-                  {likesCount}
-                </span>
-              </button>
-            ) : (
-              <LoginPromptDialog className="cursor-pointer" type="article">
-                <div className="flex items-center gap-1">
-                  <ArticleLikeIcon className="size-4 md:size-5" />
-                  <span className="text-xs md:text-sm">{likesCount}</span>
-                </div>
-              </LoginPromptDialog>
-            )}
+            <div onClick={(e) => e.stopPropagation()}>
+              {isLoggedIn ? (
+                <button
+                  onClick={handleLike}
+                  className="flex cursor-pointer items-center gap-1 transition-colors"
+                >
+                  <ArticleLikeIcon
+                    className={`size-4 transition-colors ${isLiked ? "fill-red-500 text-red-500" : ""}`}
+                  />
+                  <span className={`text-xs ${isLiked ? "text-red-500" : ""}`}>{likesCount}</span>
+                </button>
+              ) : (
+                <LoginPromptDialog className="cursor-pointer" type="article">
+                  <div className="flex items-center gap-1">
+                    <ArticleLikeIcon className="size-4" />
+                    <span className="text-xs">{likesCount}</span>
+                  </div>
+                </LoginPromptDialog>
+              )}
+            </div>
           </div>
 
-          {/* User info */}
-          <Link href={articleUrl}>
-            <div className="flex items-center">
-              <div className="mr-2 size-6 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
-                {article.profiles.avatar_url ? (
-                  <Image
-                    src={article.profiles.avatar_url}
-                    alt="Profile image"
-                    width={24}
-                    height={24}
-                    className="object-cover"
-                  />
-                ) : (
-                  <DefaultAvatar size="sm" className="size-full bg-gray-200 dark:bg-gray-700" />
-                )}
-              </div>
-              <span className="text-xs font-medium text-gray-900 md:text-sm dark:text-white">
-                {article.profiles.display_name}
-              </span>
-            </div>
-          </Link>
+          {/* 著者情報 */}
+          <div className="flex items-center gap-2">
+            <UserAvatar
+              username={article.profiles.user_name}
+              displayName={article.profiles.display_name}
+              avatarUrl={article.profiles.avatar_url}
+              size="sm"
+              linkable={false}
+            />
+            <span className="text-foreground text-xs font-medium">
+              {article.profiles.display_name}
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/features/common/ui/feed-cta-card.tsx
+++ b/apps/web/src/features/common/ui/feed-cta-card.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { AppDownloadDialogTrigger } from "@quitmate/ui";
+import { Download, LogIn } from "lucide-react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * 未ログインユーザー向けのフィード内CTAカード
+ * フィードのストーリー間に挿入して、アプリDLやログインを促す
+ */
+export function FeedCtaCard() {
+  const t = useTranslations("feed-cta");
+  const tAppDownload = useTranslations("app-download-dialog");
+
+  return (
+    <div className="border-border bg-card border-b py-6">
+      <div className="mx-auto max-w-sm px-4 text-center">
+        <p className="text-foreground mb-1 text-base font-bold">{t("title")}</p>
+        <p className="text-muted-foreground mb-4 text-sm">{t("description")}</p>
+
+        <div className="flex flex-col gap-2">
+          <AppDownloadDialogTrigger
+            title={tAppDownload("title")}
+            description={tAppDownload("description")}
+            qrCodeLabel={tAppDownload("qrCodeLabel")}
+            qrCodeAlt={tAppDownload("qrCodeAlt")}
+            storeLabel={tAppDownload("storeLabel")}
+          >
+            <Button className="w-full cursor-pointer rounded-full">
+              <Download className="mr-2 size-4" />
+              {t("downloadApp")}
+            </Button>
+          </AppDownloadDialogTrigger>
+
+          <Button asChild variant="outline" className="w-full rounded-full">
+            <Link href="/auth/sign-up">
+              <LogIn className="mr-2 size-4" />
+              {t("signUp")}
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/common/ui/feed-cta-card.tsx
+++ b/apps/web/src/features/common/ui/feed-cta-card.tsx
@@ -1,27 +1,58 @@
 "use client";
 
 import { AppDownloadDialogTrigger } from "@quitmate/ui";
-import { Download, LogIn } from "lucide-react";
+import { Download, LogIn, X } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+import { useState, useSyncExternalStore } from "react";
 
 import { Button } from "@/components/ui/button";
 
+const CTA_TRIGGER_COUNT = 5;
+const STORAGE_KEY = "feed_cta_dismissed";
+
+function getIsDismissed() {
+  return !!sessionStorage.getItem(STORAGE_KEY);
+}
+
 /**
- * 未ログインユーザー向けのフィード内CTAカード
- * フィードのストーリー間に挿入して、アプリDLやログインを促す
+ * 未ログインユーザー向けのフィード内CTAポップアップ
+ * 投稿を一定数スクロールすると画面下部に表示される
  */
-export function FeedCtaCard() {
+export function FeedCtaPopup({ viewedCount }: { viewedCount: number }) {
   const t = useTranslations("feed-cta");
   const tAppDownload = useTranslations("app-download-dialog");
+  const wasDismissedOnMount = useSyncExternalStore(
+    () => () => {},
+    getIsDismissed,
+    () => true,
+  );
+  const [dismissed, setDismissed] = useState(wasDismissedOnMount);
+
+  if (dismissed || viewedCount < CTA_TRIGGER_COUNT) return null;
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    sessionStorage.setItem(STORAGE_KEY, "1");
+  };
 
   return (
-    <div className="border-border bg-card border-b py-6">
-      <div className="mx-auto max-w-sm px-4 text-center">
-        <p className="text-foreground mb-1 text-base font-bold">{t("title")}</p>
-        <p className="text-muted-foreground mb-4 text-sm">{t("description")}</p>
+    <div className="fixed inset-x-0 bottom-16 z-40 flex justify-center px-4 md:bottom-4">
+      <div className="bg-card border-border w-full max-w-sm rounded-2xl border p-4 shadow-lg">
+        <div className="mb-3 flex items-start justify-between">
+          <div>
+            <p className="text-foreground text-sm font-bold">{t("title")}</p>
+            <p className="text-muted-foreground text-xs">{t("description")}</p>
+          </div>
+          <button
+            onClick={handleDismiss}
+            className="text-muted-foreground hover:text-foreground -mt-1 -mr-1 p-1"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
 
-        <div className="flex flex-col gap-2">
+        <div className="flex gap-2">
           <AppDownloadDialogTrigger
             title={tAppDownload("title")}
             description={tAppDownload("description")}
@@ -29,15 +60,15 @@ export function FeedCtaCard() {
             qrCodeAlt={tAppDownload("qrCodeAlt")}
             storeLabel={tAppDownload("storeLabel")}
           >
-            <Button className="w-full cursor-pointer rounded-full">
-              <Download className="mr-2 size-4" />
+            <Button size="sm" className="flex-1 cursor-pointer rounded-full">
+              <Download className="mr-1 size-3" />
               {t("downloadApp")}
             </Button>
           </AppDownloadDialogTrigger>
 
-          <Button asChild variant="outline" className="w-full rounded-full">
+          <Button asChild variant="outline" size="sm" className="flex-1 rounded-full">
             <Link href="/auth/sign-up">
-              <LogIn className="mr-2 size-4" />
+              <LogIn className="mr-1 size-3" />
               {t("signUp")}
             </Link>
           </Button>

--- a/apps/web/src/features/common/ui/feed-cta-card.tsx
+++ b/apps/web/src/features/common/ui/feed-cta-card.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
 /** 初回表示までの投稿数 */
-const FIRST_TRIGGER = 5;
+const FIRST_TRIGGER = 15;
 /** バツで閉じた後、再表示するまでの追加投稿数 */
 const REPEAT_INTERVAL = 10;
 

--- a/apps/web/src/features/common/ui/feed-cta-card.tsx
+++ b/apps/web/src/features/common/ui/feed-cta-card.tsx
@@ -16,10 +16,11 @@ function getIsDismissed() {
 }
 
 /**
- * 未ログインユーザー向けのフィード内CTAポップアップ
- * 投稿を一定数スクロールすると画面下部に表示される
+ * 未ログインユーザー向けのフィードゲートモーダル
+ * 一定数の投稿を読んだらオーバーレイで表示し、ログインまたはアプリDLを促す
+ * バツボタンで閉じると同セッション中は再表示しない
  */
-export function FeedCtaPopup({ viewedCount }: { viewedCount: number }) {
+export function FeedGate({ viewedCount }: { viewedCount: number }) {
   const t = useTranslations("feed-cta");
   const tAppDownload = useTranslations("app-download-dialog");
   const wasDismissedOnMount = useSyncExternalStore(
@@ -37,22 +38,21 @@ export function FeedCtaPopup({ viewedCount }: { viewedCount: number }) {
   };
 
   return (
-    <div className="fixed inset-x-0 bottom-16 z-40 flex justify-center px-4 md:bottom-4">
-      <div className="bg-card border-border w-full max-w-sm rounded-2xl border p-4 shadow-lg">
-        <div className="mb-3 flex items-start justify-between">
-          <div>
-            <p className="text-foreground text-sm font-bold">{t("title")}</p>
-            <p className="text-muted-foreground text-xs">{t("description")}</p>
-          </div>
-          <button
-            onClick={handleDismiss}
-            className="text-muted-foreground hover:text-foreground -mt-1 -mr-1 p-1"
-          >
-            <X className="size-4" />
-          </button>
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-card relative w-full max-w-lg rounded-t-2xl px-6 pt-6 pb-8 shadow-2xl md:mt-auto md:mb-auto md:rounded-2xl">
+        <button
+          onClick={handleDismiss}
+          className="text-muted-foreground hover:text-foreground absolute top-4 right-4 p-1"
+        >
+          <X className="size-5" />
+        </button>
+
+        <div className="mb-2 text-center">
+          <p className="text-foreground text-lg font-bold">{t("title")}</p>
+          <p className="text-muted-foreground mt-1 text-sm">{t("description")}</p>
         </div>
 
-        <div className="flex gap-2">
+        <div className="mt-6 flex flex-col gap-3">
           <AppDownloadDialogTrigger
             title={tAppDownload("title")}
             description={tAppDownload("description")}
@@ -60,18 +60,25 @@ export function FeedCtaPopup({ viewedCount }: { viewedCount: number }) {
             qrCodeAlt={tAppDownload("qrCodeAlt")}
             storeLabel={tAppDownload("storeLabel")}
           >
-            <Button size="sm" className="flex-1 cursor-pointer rounded-full">
-              <Download className="mr-1 size-3" />
+            <Button size="lg" className="w-full cursor-pointer rounded-full text-base">
+              <Download className="mr-2 size-5" />
               {t("downloadApp")}
             </Button>
           </AppDownloadDialogTrigger>
 
-          <Button asChild variant="outline" size="sm" className="flex-1 rounded-full">
+          <Button asChild variant="outline" size="lg" className="w-full rounded-full text-base">
             <Link href="/auth/sign-up">
-              <LogIn className="mr-1 size-3" />
+              <LogIn className="mr-2 size-5" />
               {t("signUp")}
             </Link>
           </Button>
+
+          <p className="text-muted-foreground mt-2 text-center text-xs">
+            {t("loginLink.prefix")}
+            <Link href="/auth/login" className="text-primary hover:underline">
+              {t("loginLink.action")}
+            </Link>
+          </p>
         </div>
       </div>
     </div>

--- a/apps/web/src/features/common/ui/feed-cta-card.tsx
+++ b/apps/web/src/features/common/ui/feed-cta-card.tsx
@@ -4,37 +4,35 @@ import { AppDownloadDialogTrigger } from "@quitmate/ui";
 import { Download, LogIn, X } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useState, useSyncExternalStore } from "react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
-const CTA_TRIGGER_COUNT = 5;
-const STORAGE_KEY = "feed_cta_dismissed";
-
-function getIsDismissed() {
-  return !!sessionStorage.getItem(STORAGE_KEY);
-}
+/** 初回表示までの投稿数 */
+const FIRST_TRIGGER = 5;
+/** バツで閉じた後、再表示するまでの追加投稿数 */
+const REPEAT_INTERVAL = 10;
 
 /**
  * 未ログインユーザー向けのフィードゲートモーダル
  * 一定数の投稿を読んだらオーバーレイで表示し、ログインまたはアプリDLを促す
- * バツボタンで閉じると同セッション中は再表示しない
+ * バツボタンで閉じてもスクロールを続けると再表示される
  */
 export function FeedGate({ viewedCount }: { viewedCount: number }) {
   const t = useTranslations("feed-cta");
   const tAppDownload = useTranslations("app-download-dialog");
-  const wasDismissedOnMount = useSyncExternalStore(
-    () => () => {},
-    getIsDismissed,
-    () => true,
-  );
-  const [dismissed, setDismissed] = useState(wasDismissedOnMount);
+  const [dismissedAt, setDismissedAt] = useState<number | null>(null);
 
-  if (dismissed || viewedCount < CTA_TRIGGER_COUNT) return null;
+  // 表示条件: 初回は FIRST_TRIGGER件目、閉じた後は閉じた時点から REPEAT_INTERVAL件後
+  const shouldShow =
+    dismissedAt === null
+      ? viewedCount >= FIRST_TRIGGER
+      : viewedCount >= dismissedAt + REPEAT_INTERVAL;
+
+  if (!shouldShow) return null;
 
   const handleDismiss = () => {
-    setDismissed(true);
-    sessionStorage.setItem(STORAGE_KEY, "1");
+    setDismissedAt(viewedCount);
   };
 
   return (

--- a/apps/web/src/features/common/ui/feed-cta-card.tsx
+++ b/apps/web/src/features/common/ui/feed-cta-card.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button";
 /** 初回表示までの投稿数 */
 const FIRST_TRIGGER = 15;
 /** バツで閉じた後、再表示するまでの追加投稿数 */
-const REPEAT_INTERVAL = 10;
+const REPEAT_INTERVAL = 15;
 
 /**
  * 未ログインユーザー向けのフィードゲートモーダル

--- a/apps/web/src/features/profiles/ui/profile-options-menu.tsx
+++ b/apps/web/src/features/profiles/ui/profile-options-menu.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition, useEffect } from "react";
 import { MoreHorizontal, VolumeX, Volume2, Flag } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 import {
   DropdownMenu,
@@ -28,9 +29,7 @@ export function ProfileOptionsMenu({ targetUserId, initialIsMuted = false, onMut
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
-  const [showSuccess, setShowSuccess] = useState(false);
   const [isMuted, setIsMuted] = useState(initialIsMuted);
-  const [successMessage, setSuccessMessage] = useState("");
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
 
   // propsが変わったらstateを同期
@@ -43,9 +42,7 @@ export function ProfileOptionsMenu({ targetUserId, initialIsMuted = false, onMut
       const result = await muteUser(targetUserId);
       if (result.success) {
         setIsMuted(true);
-        setSuccessMessage(t("success"));
-        setShowSuccess(true);
-        setTimeout(() => setShowSuccess(false), 3000);
+        toast.success(t("success"));
         onMuteSuccess?.();
         router.refresh();
       }
@@ -58,9 +55,7 @@ export function ProfileOptionsMenu({ targetUserId, initialIsMuted = false, onMut
       const result = await unmuteUser(targetUserId);
       if (result.success) {
         setIsMuted(false);
-        setSuccessMessage(t("unmuteSuccess"));
-        setShowSuccess(true);
-        setTimeout(() => setShowSuccess(false), 3000);
+        toast.success(t("unmuteSuccess"));
         router.refresh();
       }
       setOpen(false);
@@ -110,13 +105,6 @@ export function ProfileOptionsMenu({ targetUserId, initialIsMuted = false, onMut
         onOpenChange={setReportDialogOpen}
         reportDTO={{ type: ReportType.user, itemId: targetUserId }}
       />
-
-      {/* スナックバー表示 */}
-      {showSuccess && (
-        <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-green-600 px-4 py-2 text-white shadow-lg">
-          {successMessage}
-        </div>
-      )}
     </>
   );
 }

--- a/apps/web/src/features/reports/ui/report-dialog.tsx
+++ b/apps/web/src/features/reports/ui/report-dialog.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useTransition } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 import {
   Dialog,
@@ -55,21 +56,16 @@ export function ReportDialog({ open, onOpenChange, reportDTO }: ReportDialogProp
   const t = useTranslations("reportDialog");
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const [showSuccess, setShowSuccess] = useState(false);
 
   const handleReport = () => {
     startTransition(async () => {
       const result = await reportItem(reportDTO);
       if (result.success) {
-        setShowSuccess(true);
-        setTimeout(() => {
-          setShowSuccess(false);
-          onOpenChange(false);
-          router.refresh();
-        }, 2000);
+        toast.success(t("reportComplete"));
+        onOpenChange(false);
+        router.refresh();
       } else {
-        // エラー時はコンソールに出力（将来的にスナックバーで表示する場合は翻訳を使用）
-        console.error("[ReportDialog] Error:", result.error);
+        toast.error(result.error ?? "Report failed");
       }
     });
   };
@@ -94,13 +90,6 @@ export function ReportDialog({ open, onOpenChange, reportDTO }: ReportDialogProp
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
-      {/* 成功メッセージ */}
-      {showSuccess && (
-        <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-green-600 px-4 py-2 text-white shadow-lg">
-          {t("reportComplete")}
-        </div>
-      )}
     </>
   );
 }

--- a/apps/web/src/features/settings/ui/muted-accounts-content.tsx
+++ b/apps/web/src/features/settings/ui/muted-accounts-content.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 import { ArrowLeft, VolumeX } from "lucide-react";
 import Link from "next/link";
 
@@ -19,15 +20,13 @@ export function MutedAccountsContent({ initialMutedUsers }: Props) {
   const tMute = useTranslations("mute");
   const [mutedUsers, setMutedUsers] = useState(initialMutedUsers);
   const [isPending, startTransition] = useTransition();
-  const [showSuccess, setShowSuccess] = useState(false);
 
   const handleUnmute = (userId: string) => {
     startTransition(async () => {
       const result = await unmuteUser(userId);
       if (result.success) {
         setMutedUsers((prev) => prev.filter((user) => user.id !== userId));
-        setShowSuccess(true);
-        setTimeout(() => setShowSuccess(false), 3000);
+        toast.success(tMute("unmuteSuccess"));
       }
     });
   };
@@ -76,13 +75,6 @@ export function MutedAccountsContent({ initialMutedUsers }: Props) {
               </Button>
             </div>
           ))}
-        </div>
-      )}
-
-      {/* スナックバー表示 */}
-      {showSuccess && (
-        <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-green-600 px-4 py-2 text-white shadow-lg">
-          {tMute("unmuteSuccess")}
         </div>
       )}
     </div>

--- a/apps/web/src/features/settings/ui/settings-content.tsx
+++ b/apps/web/src/features/settings/ui/settings-content.tsx
@@ -25,7 +25,7 @@ export function SettingsContent() {
   const handleLogout = async () => {
     const supabase = createClient();
     await supabase.auth.signOut();
-    router.push("/auth/login");
+    router.push("/stories/habits/all");
   };
 
   const settingsItems = [

--- a/apps/web/src/features/stories/ui/comment-form.tsx
+++ b/apps/web/src/features/stories/ui/comment-form.tsx
@@ -16,9 +16,10 @@ type Props = {
   storyId: string;
   replyTarget?: ParentCommentInfo | null;
   onCancelReply?: () => void;
+  onOptimisticAdd?: (content: string, parentComment?: ParentCommentInfo | null) => void;
 };
 
-export function CommentForm({ storyId, replyTarget, onCancelReply }: Props) {
+export function CommentForm({ storyId, replyTarget, onCancelReply, onOptimisticAdd }: Props) {
   const t = useTranslations("comment-form");
   const [content, setContent] = useState("");
   const [isPending, startTransition] = useTransition();
@@ -49,14 +50,15 @@ export function CommentForm({ storyId, replyTarget, onCancelReply }: Props) {
       return;
     }
 
+    // 楽観的更新
+    onOptimisticAdd?.(content, replyTarget);
+    setContent("");
+    onCancelReply?.();
+
     startTransition(async () => {
       const result = await createComment(storyId, content, replyTarget?.id);
 
-      if (result.success) {
-        setContent("");
-        setError(null);
-        onCancelReply?.(); // 返信モードをリセット
-      } else {
+      if (!result.success) {
         setError(t("postFailed"));
       }
     });

--- a/apps/web/src/features/stories/ui/comment-tile.tsx
+++ b/apps/web/src/features/stories/ui/comment-tile.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, useTransition, useEffect } from "react";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
 import { CommentTileDto } from "@/lib/types";
 
@@ -52,10 +53,7 @@ export function CommentTile({
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
-  const [showMuteSuccess, setShowMuteSuccess] = useState(false);
   const [isMuted, setIsMuted] = useState(isMutedOwner);
-  const [successMessage, setSuccessMessage] = useState("");
-  const [showDeleteSuccess, setShowDeleteSuccess] = useState(false);
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
 
   const isMyComment = currentUserId === comment.user_id;
@@ -70,9 +68,7 @@ export function CommentTile({
       const result = await muteUser(comment.user_id);
       if (result.success) {
         setIsMuted(true);
-        setSuccessMessage(t("success"));
-        setShowMuteSuccess(true);
-        setTimeout(() => setShowMuteSuccess(false), 3000);
+        toast.success(t("success"));
         router.refresh();
       }
       setMenuOpen(false);
@@ -84,9 +80,7 @@ export function CommentTile({
       const result = await unmuteUser(comment.user_id);
       if (result.success) {
         setIsMuted(false);
-        setSuccessMessage(t("unmuteSuccess"));
-        setShowMuteSuccess(true);
-        setTimeout(() => setShowMuteSuccess(false), 3000);
+        toast.success(t("unmuteSuccess"));
         router.refresh();
       }
       setMenuOpen(false);
@@ -100,8 +94,7 @@ export function CommentTile({
     startTransition(async () => {
       const result = await deleteComment(comment.id);
       if (result.success) {
-        setShowDeleteSuccess(true);
-        setTimeout(() => setShowDeleteSuccess(false), 3000);
+        toast.success(tDelete("success"));
         router.refresh();
       } else {
         // エラー時はコンソールに出力（将来的にスナックバーで表示する場合は翻訳を使用）
@@ -137,8 +130,14 @@ export function CommentTile({
     locale: ja,
   });
 
+  const isReply = !!comment.parent_comment_id;
+
   return (
-    <div className="border-border flex border-b p-3 pl-12">
+    <div
+      className={`border-border flex border-b p-3 ${
+        isReply ? "border-primary/30 border-l-2 pl-14" : "pl-12"
+      }`}
+    >
       {/* アバター */}
       <div className="mr-2">
         <UserAvatar
@@ -151,8 +150,8 @@ export function CommentTile({
 
       {/* コメント本文 */}
       <div className="flex-1">
-        <div className="mb-0.5 flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
+        <div className="mb-1 flex items-center justify-between">
+          <div className="flex items-center gap-2">
             <Link href={`/${comment.profiles.user_name}`} className="hover:underline">
               <span className="text-foreground text-sm font-bold">
                 {comment.profiles.display_name}
@@ -169,8 +168,8 @@ export function CommentTile({
           {isLoggedIn && (
             <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="size-6">
-                  <MoreHorizontal className="size-3" />
+                <Button variant="ghost" size="icon" className="size-8">
+                  <MoreHorizontal className="size-4" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
@@ -221,7 +220,7 @@ export function CommentTile({
           )}
         </div>
 
-        <p className="text-foreground whitespace-pre-wrap text-sm">
+        <p className="text-foreground text-sm whitespace-pre-wrap">
           {/* 返信先表示（返信コメントの場合） */}
           {comment.parent_comment?.profiles?.display_name && (
             <span className="text-primary mr-1 font-medium">
@@ -267,20 +266,6 @@ export function CommentTile({
           </AppDownloadDialogTrigger>
         </div>
       </div>
-
-      {/* ミュート成功スナックバー */}
-      {showMuteSuccess && (
-        <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-green-600 px-4 py-2 text-white shadow-lg">
-          {successMessage}
-        </div>
-      )}
-
-      {/* 削除成功スナックバー */}
-      {showDeleteSuccess && (
-        <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-green-600 px-4 py-2 text-white shadow-lg">
-          {tDelete("success")}
-        </div>
-      )}
 
       {/* 報告ダイアログ */}
       {!isMyComment && (

--- a/apps/web/src/features/stories/ui/comments-section.tsx
+++ b/apps/web/src/features/stories/ui/comments-section.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 import { CommentTileDto, ParentCommentInfo } from "@/lib/types";
+import { useCurrentUser } from "@/features/common/providers/current-user-provider";
 
 import { CommentForm } from "./comment-form";
 import { CommentTile } from "./comment-tile";
@@ -23,6 +24,17 @@ export function CommentsSection({
   currentUserId,
 }: Props) {
   const [replyTarget, setReplyTarget] = useState<ParentCommentInfo | null>(null);
+  const [optimisticComments, setOptimisticComments] = useState<CommentTileDto[]>([]);
+  const [prevComments, setPrevComments] = useState(comments);
+  const { profile } = useCurrentUser();
+
+  // サーバーからコメントが更新されたら楽観的コメントをクリア（propsに基づくstate調整）
+  if (prevComments !== comments) {
+    setPrevComments(comments);
+    if (optimisticComments.length > 0) {
+      setOptimisticComments([]);
+    }
+  }
 
   const handleReply = (comment: CommentTileDto) => {
     setReplyTarget({
@@ -35,6 +47,30 @@ export function CommentsSection({
     setReplyTarget(null);
   };
 
+  const handleCommentCreated = (content: string, parentComment?: ParentCommentInfo | null) => {
+    if (!profile) return;
+
+    const optimistic: CommentTileDto = {
+      id: `optimistic-${Date.now()}`,
+      story_id: storyId,
+      user_id: currentUserId ?? "",
+      content,
+      created_at: new Date().toISOString(),
+      parent_comment_id: parentComment?.id ?? null,
+      profiles: {
+        user_name: profile.user_name,
+        display_name: profile.display_name,
+        avatar_url: profile.avatar_url,
+      },
+      comment_likes: [{ count: 0 }],
+      parent_comment: parentComment ?? null,
+    };
+
+    setOptimisticComments((prev) => [...prev, optimistic]);
+  };
+
+  const allComments = [...(comments ?? []), ...optimisticComments];
+
   return (
     <>
       {/* コメントフォーム */}
@@ -43,13 +79,14 @@ export function CommentsSection({
           storyId={storyId}
           replyTarget={replyTarget}
           onCancelReply={handleCancelReply}
+          onOptimisticAdd={handleCommentCreated}
         />
       )}
 
       {/* コメント一覧 */}
-      {comments && comments.length > 0 && (
+      {allComments.length > 0 && (
         <div className="mt-4">
-          {comments.map((comment) => (
+          {allComments.map((comment) => (
             <CommentTile
               key={comment.id}
               comment={comment}

--- a/apps/web/src/features/stories/ui/following-story-list.tsx
+++ b/apps/web/src/features/stories/ui/following-story-list.tsx
@@ -5,13 +5,12 @@ import { useInView } from "react-intersection-observer";
 import { useTranslations } from "next-intl";
 import { UserPlus } from "lucide-react";
 
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
-
 import { HabitTileDto } from "@/lib/types";
 
 import { useInfiniteFollowingStories } from "../hooks/use-infinite-following-stories";
 import { StoryTile } from "./story-tile";
 import { StoryInlineForm } from "./story-inline-form";
+import { StoryListSkeleton } from "./story-tile-skeleton";
 
 type Props = {
   habits?: HabitTileDto[];
@@ -46,10 +45,14 @@ export function FollowingStoryList({ habits, currentUserId }: Props) {
     );
   }
 
+  if (isLoading) {
+    return <StoryListSkeleton />;
+  }
+
   // 空状態
-  if (!isLoading && stories.length === 0) {
+  if (stories.length === 0) {
     return (
-      <div className="mx-auto max-w-2xl">
+      <div className="mx-auto max-w-[600px]">
         {habits && habits.length > 0 && <StoryInlineForm habits={habits} />}
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <div className="bg-muted mb-4 rounded-full p-4">
@@ -63,7 +66,7 @@ export function FollowingStoryList({ habits, currentUserId }: Props) {
   }
 
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto max-w-[600px]">
       {habits && habits.length > 0 && <StoryInlineForm habits={habits} />}
 
       {stories.map((story) => (
@@ -72,9 +75,9 @@ export function FollowingStoryList({ habits, currentUserId }: Props) {
 
       {/* ローディング & 読み込みトリガー */}
       <div ref={ref} className="py-4">
-        {(isLoading || isFetchingNextPage) && (
+        {isFetchingNextPage && (
           <div className="flex justify-center">
-            <LoadingSpinner />
+            <StoryListSkeleton count={2} />
           </div>
         )}
         {!hasNextPage && stories.length > 0 && (

--- a/apps/web/src/features/stories/ui/story-detail-content.tsx
+++ b/apps/web/src/features/stories/ui/story-detail-content.tsx
@@ -44,7 +44,7 @@ export function StoryDetailContent({
         idleLabel={tPull("pullToRefresh")}
         refreshingLabel={tPull("refreshing")}
       />
-      <div className="mx-auto max-w-2xl space-y-6">
+      <div className="mx-auto max-w-[600px] space-y-6">
         <StoryTile
           story={story}
           disableLink

--- a/apps/web/src/features/stories/ui/story-inline-form.tsx
+++ b/apps/web/src/features/stories/ui/story-inline-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useState, useTransition, useEffect, useRef } from "react";
+import { useState, useSyncExternalStore, useTransition, useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
@@ -34,7 +34,6 @@ export function StoryInlineForm({
   const [error, setError] = useState<string | null>(null);
   const [content, setContent] = useState("");
   const [commentSetting, setCommentSetting] = useState<CommentSetting>("enabled");
-  const [isMounted, setIsMounted] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const activeHabits = getActiveHabits(habits);
@@ -46,10 +45,12 @@ export function StoryInlineForm({
 
   const { remaining, isOverLimit, showCount, progress } = useCharacterCount(content);
 
-  // ハイドレーションミスマッチを防ぐため、マウント後にのみ表示
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
+  // ハイドレーションミスマッチを防ぐため、サーバーではfalse、クライアントではtrue
+  const isMounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
 
   // テキストエリアの高さを自動調整
   useEffect(() => {
@@ -102,7 +103,7 @@ export function StoryInlineForm({
     <div className="border-border bg-card border-b">
       <form onSubmit={handleSubmit} className="flex flex-col">
         {/* 習慣選択とコメント設定 */}
-        <div className="flex items-center gap-1.5 px-3 pb-1.5 pt-2 md:gap-2 md:px-4 md:pb-2 md:pt-3">
+        <div className="flex items-center gap-2 px-3 pt-3 pb-2 md:px-4">
           <HabitSelectDropdown
             habits={activeHabits}
             selectedHabitId={selectedHabitId}
@@ -113,7 +114,7 @@ export function StoryInlineForm({
         </div>
 
         {/* テキストエリア */}
-        <div className="px-3 py-1.5 md:px-4 md:py-2">
+        <div className="px-3 py-2 md:px-4">
           <textarea
             ref={textareaRef}
             name="content"
@@ -128,13 +129,13 @@ export function StoryInlineForm({
         </div>
 
         {error && (
-          <div className="px-3 pb-1.5 md:px-4 md:pb-2">
+          <div className="px-3 pb-2 md:px-4">
             <p className="text-xs text-red-500 md:text-sm">{error}</p>
           </div>
         )}
 
         {/* フッター（文字数カウント、投稿ボタン） */}
-        <div className="flex items-center justify-end gap-2 px-3 pb-2 pt-1.5 md:gap-3 md:px-4 md:pb-3 md:pt-2">
+        <div className="flex items-center justify-end gap-2 px-3 pt-2 pb-3 md:gap-3 md:px-4">
           <CharacterCountIndicator
             remaining={remaining}
             isOverLimit={isOverLimit}
@@ -145,7 +146,7 @@ export function StoryInlineForm({
           <Button
             type="submit"
             disabled={isPending || !content.trim() || isOverLimit}
-            className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-full px-4 py-1.5 text-xs font-semibold disabled:opacity-50 md:px-6 md:py-2 md:text-sm"
+            className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-full px-4 py-2 text-xs font-semibold disabled:opacity-50 md:px-6 md:text-sm"
           >
             {t("postButton")}
           </Button>

--- a/apps/web/src/features/stories/ui/story-list-infinite-by-user.tsx
+++ b/apps/web/src/features/stories/ui/story-list-infinite-by-user.tsx
@@ -6,10 +6,9 @@ import { useTranslations } from "next-intl";
 
 import { TranslatedAppDownloadSection } from "@/components/ui/translated-app-download-section";
 
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
-
 import { useInfiniteStoriesByUserId } from "../hooks/use-infinite-stories-by-user";
 import { StoryTile } from "./story-tile";
+import { StoryListSkeleton } from "./story-tile-skeleton";
 
 type Props = {
   userId: string;
@@ -51,7 +50,7 @@ export function StoryListInfiniteByUser({
   }
 
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto max-w-[600px]">
       {stories.map((story) => (
         <StoryTile
           key={story.id}
@@ -63,11 +62,7 @@ export function StoryListInfiniteByUser({
       ))}
 
       <div ref={ref} className="py-4">
-        {(isLoading || isFetchingNextPage) && (
-          <div className="flex justify-center">
-            <LoadingSpinner />
-          </div>
-        )}
+        {isFetchingNextPage && <StoryListSkeleton count={2} />}
         {!hasNextPage && stories.length > 0 && (
           <p className="text-muted-foreground py-4 text-center text-sm">
             {t("noMoreStories", { defaultValue: "すべてのストーリーを読み込みました" })}

--- a/apps/web/src/features/stories/ui/story-list-infinite-commented.tsx
+++ b/apps/web/src/features/stories/ui/story-list-infinite-commented.tsx
@@ -6,10 +6,9 @@ import { useTranslations } from "next-intl";
 
 import { TranslatedAppDownloadSection } from "@/components/ui/translated-app-download-section";
 
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
-
 import { useInfiniteCommentedStories } from "../hooks/use-infinite-commented-stories";
 import { StoryTile } from "./story-tile";
+import { StoryListSkeleton } from "./story-tile-skeleton";
 
 type Props = {
   userId: string;
@@ -44,7 +43,7 @@ export function StoryListInfiniteCommented({ userId, isLoggedIn, currentUserId }
   }
 
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto max-w-[600px]">
       {stories.map((story) => (
         <StoryTile
           key={story.id}
@@ -55,11 +54,7 @@ export function StoryListInfiniteCommented({ userId, isLoggedIn, currentUserId }
       ))}
 
       <div ref={ref} className="py-4">
-        {(isLoading || isFetchingNextPage) && (
-          <div className="flex justify-center">
-            <LoadingSpinner />
-          </div>
-        )}
+        {isFetchingNextPage && <StoryListSkeleton count={2} />}
         {!hasNextPage && stories.length > 0 && (
           <p className="text-muted-foreground py-4 text-center text-sm">
             {t("noMoreStories", { defaultValue: "すべてのストーリーを読み込みました" })}

--- a/apps/web/src/features/stories/ui/story-list-infinite.tsx
+++ b/apps/web/src/features/stories/ui/story-list-infinite.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useInView } from "react-intersection-observer";
 import { useTranslations } from "next-intl";
 
@@ -46,6 +46,34 @@ export function StoryListInfinite({ category, isLoggedIn, habits, currentUserId 
     enabled: true,
   });
 
+  // 実際にビューポートに表示された投稿数をカウント
+  const [viewedCount, setViewedCount] = useState(0);
+  const viewedIdsRef = useRef(new Set<string>());
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const storyRefCallback = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    observerRef.current?.observe(node);
+  }, []);
+
+  useEffect(() => {
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const id = (entry.target as HTMLElement).dataset.storyId;
+            if (id && !viewedIdsRef.current.has(id)) {
+              viewedIdsRef.current.add(id);
+              setViewedCount(viewedIdsRef.current.size);
+            }
+          }
+        }
+      },
+      { threshold: 0.5 },
+    );
+    return () => observerRef.current?.disconnect();
+  }, []);
+
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
@@ -85,15 +113,12 @@ export function StoryListInfinite({ category, isLoggedIn, habits, currentUserId 
         )}
 
         {stories.map((story) => (
-          <StoryTile
-            key={story.id}
-            story={story}
-            isLoggedIn={isLoggedIn}
-            currentUserId={currentUserId}
-          />
+          <div key={story.id} ref={storyRefCallback} data-story-id={story.id}>
+            <StoryTile story={story} isLoggedIn={isLoggedIn} currentUserId={currentUserId} />
+          </div>
         ))}
 
-        {!isLoggedIn && <FeedGate viewedCount={stories.length} />}
+        {!isLoggedIn && <FeedGate viewedCount={viewedCount} />}
 
         <div ref={ref} className="py-4">
           {isFetchingNextPage && (

--- a/apps/web/src/features/stories/ui/story-list-infinite.tsx
+++ b/apps/web/src/features/stories/ui/story-list-infinite.tsx
@@ -7,13 +7,13 @@ import { useTranslations } from "next-intl";
 import { TranslatedAppDownloadSection } from "@/components/ui/translated-app-download-section";
 
 import { HabitCategoryName, HabitTileDto } from "@/lib/types";
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
-
 import { useInfiniteStories } from "../hooks/use-infinite-stories";
+import { StoryListSkeleton } from "./story-tile-skeleton";
 import { usePullToRefresh } from "@/features/common/hooks/use-pull-to-refresh";
 import { StoryTile } from "./story-tile";
 import { StoryInlineForm } from "./story-inline-form";
 import { PullToRefreshIndicator } from "@/features/common/ui/pull-to-refresh-indicator";
+import { FeedCtaCard } from "@/features/common/ui/feed-cta-card";
 
 type Props = {
   category: HabitCategoryName;
@@ -62,16 +62,20 @@ export function StoryListInfinite({ category, isLoggedIn, habits, currentUserId 
     );
   }
 
+  if (isLoading) {
+    return <StoryListSkeleton />;
+  }
+
   return (
     <>
       <PullToRefreshIndicator
-        isRefreshing={isRefreshing || isLoading}
+        isRefreshing={isRefreshing}
         pullProgress={pullProgress}
         shouldShow={shouldShowIndicator}
         idleLabel={tPull("pullToRefresh")}
         refreshingLabel={tPull("refreshing")}
       />
-      <div className="mx-auto max-w-2xl">
+      <div className="mx-auto max-w-[600px]">
         {habits && habits.length > 0 && (
           <StoryInlineForm
             habits={habits}
@@ -80,19 +84,18 @@ export function StoryListInfinite({ category, isLoggedIn, habits, currentUserId 
           />
         )}
 
-        {stories.map((story) => (
-          <StoryTile
-            key={story.id}
-            story={story}
-            isLoggedIn={isLoggedIn}
-            currentUserId={currentUserId}
-          />
+        {stories.map((story, index) => (
+          <div key={story.id}>
+            <StoryTile story={story} isLoggedIn={isLoggedIn} currentUserId={currentUserId} />
+            {!isLoggedIn && index === 2 && <FeedCtaCard />}
+            {!isLoggedIn && index > 2 && index % 10 === 9 && <FeedCtaCard />}
+          </div>
         ))}
 
         <div ref={ref} className="py-4">
-          {(isLoading || isFetchingNextPage) && (
+          {isFetchingNextPage && (
             <div className="flex justify-center">
-              <LoadingSpinner />
+              <StoryListSkeleton count={2} />
             </div>
           )}
           {!hasNextPage && stories.length > 0 && (
@@ -100,7 +103,7 @@ export function StoryListInfinite({ category, isLoggedIn, habits, currentUserId 
               {t("noMoreStories", { defaultValue: "すべてのストーリーを読み込みました" })}
             </p>
           )}
-          {stories.length === 0 && !isLoading && (
+          {stories.length === 0 && (
             <p className="text-muted-foreground py-8 text-center text-sm">
               {t("noStories", { defaultValue: "まだストーリーがありません" })}
             </p>

--- a/apps/web/src/features/stories/ui/story-list-infinite.tsx
+++ b/apps/web/src/features/stories/ui/story-list-infinite.tsx
@@ -13,7 +13,7 @@ import { usePullToRefresh } from "@/features/common/hooks/use-pull-to-refresh";
 import { StoryTile } from "./story-tile";
 import { StoryInlineForm } from "./story-inline-form";
 import { PullToRefreshIndicator } from "@/features/common/ui/pull-to-refresh-indicator";
-import { FeedCtaPopup } from "@/features/common/ui/feed-cta-card";
+import { FeedGate } from "@/features/common/ui/feed-cta-card";
 
 type Props = {
   category: HabitCategoryName;
@@ -93,7 +93,7 @@ export function StoryListInfinite({ category, isLoggedIn, habits, currentUserId 
           />
         ))}
 
-        {!isLoggedIn && <FeedCtaPopup viewedCount={stories.length} />}
+        {!isLoggedIn && <FeedGate viewedCount={stories.length} />}
 
         <div ref={ref} className="py-4">
           {isFetchingNextPage && (

--- a/apps/web/src/features/stories/ui/story-list-infinite.tsx
+++ b/apps/web/src/features/stories/ui/story-list-infinite.tsx
@@ -13,7 +13,7 @@ import { usePullToRefresh } from "@/features/common/hooks/use-pull-to-refresh";
 import { StoryTile } from "./story-tile";
 import { StoryInlineForm } from "./story-inline-form";
 import { PullToRefreshIndicator } from "@/features/common/ui/pull-to-refresh-indicator";
-import { FeedCtaCard } from "@/features/common/ui/feed-cta-card";
+import { FeedCtaPopup } from "@/features/common/ui/feed-cta-card";
 
 type Props = {
   category: HabitCategoryName;
@@ -84,13 +84,16 @@ export function StoryListInfinite({ category, isLoggedIn, habits, currentUserId 
           />
         )}
 
-        {stories.map((story, index) => (
-          <div key={story.id}>
-            <StoryTile story={story} isLoggedIn={isLoggedIn} currentUserId={currentUserId} />
-            {!isLoggedIn && index === 2 && <FeedCtaCard />}
-            {!isLoggedIn && index > 2 && index % 10 === 9 && <FeedCtaCard />}
-          </div>
+        {stories.map((story) => (
+          <StoryTile
+            key={story.id}
+            story={story}
+            isLoggedIn={isLoggedIn}
+            currentUserId={currentUserId}
+          />
         ))}
+
+        {!isLoggedIn && <FeedCtaPopup viewedCount={stories.length} />}
 
         <div ref={ref} className="py-4">
           {isFetchingNextPage && (

--- a/apps/web/src/features/stories/ui/story-list.tsx
+++ b/apps/web/src/features/stories/ui/story-list.tsx
@@ -27,7 +27,7 @@ export async function StoryList({ fetchStoriesFunc, habits }: StoryListProps) {
   const storiesWithLikeStatus = isLoggedIn ? await enrichStoriesWithLikeStatus(stories) : stories;
 
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto max-w-[600px]">
       {habits && habits.length > 0 && <StoryInlineForm habits={habits} />}
 
       {storiesWithLikeStatus.map((story) => (

--- a/apps/web/src/features/stories/ui/story-tile-skeleton.tsx
+++ b/apps/web/src/features/stories/ui/story-tile-skeleton.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function StoryTileSkeleton() {
+  return (
+    <div className="border-border flex border-b py-4">
+      <div className="mr-3">
+        <Skeleton className="size-12 rounded-full" />
+      </div>
+      <div className="flex-1">
+        <div className="mb-1 flex items-center gap-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+        <div className="mb-2">
+          <Skeleton className="h-5 w-20 rounded-full" />
+        </div>
+        <div className="mb-3 space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+        <div className="flex gap-4">
+          <Skeleton className="h-4 w-10" />
+          <Skeleton className="h-4 w-10" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function StoryListSkeleton({ count = 5 }: { count?: number }) {
+  return (
+    <div className="mx-auto max-w-[600px]">
+      {Array.from({ length: count }).map((_, i) => (
+        <StoryTileSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/stories/ui/story-tile.tsx
+++ b/apps/web/src/features/stories/ui/story-tile.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 import { useState, useTransition, useEffect } from "react";
 import { MoreHorizontal, VolumeX, Volume2, Trash2, Flag } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
 import { StoryTileDto } from "@/lib/types";
 
@@ -56,11 +57,9 @@ export function StoryTile({
   const [likesCount, setLikesCount] = useState(story.likes[0]?.count ?? 0);
   const [isPending, startTransition] = useTransition();
   const [menuOpen, setMenuOpen] = useState(false);
-  const [showMuteSuccess, setShowMuteSuccess] = useState(false);
   const [isMuted, setIsMuted] = useState(isMutedOwner);
-  const [successMessage, setSuccessMessage] = useState("");
-  const [showDeleteSuccess, setShowDeleteSuccess] = useState(false);
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
+  const [likeAnimating, setLikeAnimating] = useState(false);
 
   // propsが変わったらstateを同期
   useEffect(() => {
@@ -74,9 +73,7 @@ export function StoryTile({
       const result = await muteUser(story.user_id);
       if (result.success) {
         setIsMuted(true);
-        setSuccessMessage(t("success"));
-        setShowMuteSuccess(true);
-        setTimeout(() => setShowMuteSuccess(false), 3000);
+        toast.success(t("success"));
         router.refresh();
       }
       setMenuOpen(false);
@@ -88,9 +85,7 @@ export function StoryTile({
       const result = await unmuteUser(story.user_id);
       if (result.success) {
         setIsMuted(false);
-        setSuccessMessage(t("unmuteSuccess"));
-        setShowMuteSuccess(true);
-        setTimeout(() => setShowMuteSuccess(false), 3000);
+        toast.success(t("unmuteSuccess"));
         router.refresh();
       }
       setMenuOpen(false);
@@ -104,8 +99,7 @@ export function StoryTile({
     startTransition(async () => {
       const result = await deleteStory(story.id);
       if (result.success) {
-        setShowDeleteSuccess(true);
-        setTimeout(() => setShowDeleteSuccess(false), 3000);
+        toast.success(tDelete("success"));
         router.refresh();
       } else {
         // エラー時はコンソールに出力（将来的にスナックバーで表示する場合は翻訳を使用）
@@ -121,6 +115,10 @@ export function StoryTile({
     // 楽観的更新（即座にUI更新）
     setIsLiked(shouldLike);
     setLikesCount((prev) => (shouldLike ? prev + 1 : prev - 1));
+    if (shouldLike) {
+      setLikeAnimating(true);
+      setTimeout(() => setLikeAnimating(false), 350);
+    }
 
     // バックグラウンドでDB保存
     startTransition(async () => {
@@ -182,35 +180,24 @@ export function StoryTile({
 
   return (
     <div
-      className="hover:bg-accent/5 block cursor-pointer border-b border-gray-300 transition-colors dark:border-gray-700"
+      className="hover:bg-accent/5 border-border block cursor-pointer border-b transition-colors"
       onClick={handleClick}
     >
       <div className="flex px-0 py-4">
         {/* アバター部分 */}
         <div
-          className="mr-2 md:mr-3"
+          className="mr-3"
           onClick={(e) => {
             e.stopPropagation();
-            // ここでプロフィールページに遷移
             router.push(`/${story.profiles.user_name}`);
           }}
         >
-          <div className="md:hidden">
-            <UserAvatar
-              username={story.profiles.user_name}
-              displayName={story.profiles.display_name}
-              avatarUrl={story.profiles.avatar_url}
-              size="sm"
-            />
-          </div>
-          <div className="hidden md:block">
-            <UserAvatar
-              username={story.profiles.user_name}
-              displayName={story.profiles.display_name}
-              avatarUrl={story.profiles.avatar_url}
-              size="md"
-            />
-          </div>
+          <UserAvatar
+            username={story.profiles.user_name}
+            displayName={story.profiles.display_name}
+            avatarUrl={story.profiles.avatar_url}
+            size="md"
+          />
         </div>
 
         {/* メインコンテンツ */}
@@ -222,7 +209,7 @@ export function StoryTile({
               e.stopPropagation();
             }}
           >
-            <div className="flex items-center gap-1.5 md:gap-2">
+            <div className="flex items-center gap-2">
               <Link href={`/${story.profiles.user_name}`} className="hover:underline">
                 <span className="text-foreground text-sm font-bold md:text-base">
                   {story.profiles.display_name}
@@ -296,7 +283,7 @@ export function StoryTile({
           {/* クリック可能領域 - 全体がクリック可能になったので特別なクラスは不要 */}
           <div>
             {/* 習慣カテゴリーとカウント */}
-            <div className="mb-1.5 flex items-center gap-1.5 md:mb-2 md:gap-2">
+            <div className="mb-2 flex items-center gap-2">
               <CategoryTag
                 category={story.habit_categories.habit_category_name}
                 customHabitName={story.custom_habit_name}
@@ -308,12 +295,12 @@ export function StoryTile({
 
             {/* 本文 - AutoLinkTextを使用 */}
             <div
-              className="text-foreground mb-2.5 whitespace-pre-wrap text-sm md:mb-3 md:text-base"
+              className="text-foreground mb-3 text-sm whitespace-pre-wrap md:text-base"
               onClick={handleContentClick}
             >
               <AutoLinkText text={displayContent} />
               {isContentTruncated && (
-                <span className="ml-1 cursor-pointer text-xs font-medium text-green-800 md:text-sm dark:text-green-500">
+                <span className="text-primary ml-1 cursor-pointer text-xs font-medium md:text-sm">
                   {tStories("showMore")}
                 </span>
               )}
@@ -338,13 +325,12 @@ export function StoryTile({
               {isLoggedIn ? (
                 <button
                   onClick={handleLike}
-                  disabled={isPending}
-                  className="flex cursor-pointer items-center gap-1 transition-colors disabled:opacity-50"
+                  className="flex cursor-pointer items-center gap-1 transition-colors"
                 >
                   <StoryLikeIcon
                     className={`size-4 transition-colors md:size-5 ${
                       isLiked ? "fill-green-600 text-green-600" : ""
-                    }`}
+                    } ${likeAnimating ? "animate-like-bounce" : ""}`}
                   />
                   <span className={`text-xs md:text-sm ${isLiked ? "text-green-600" : ""}`}>
                     {likesCount}
@@ -362,20 +348,6 @@ export function StoryTile({
           </div>
         </div>
       </div>
-
-      {/* ミュート成功スナックバー */}
-      {showMuteSuccess && (
-        <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-green-600 px-4 py-2 text-white shadow-lg">
-          {successMessage}
-        </div>
-      )}
-
-      {/* 削除成功スナックバー */}
-      {showDeleteSuccess && (
-        <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-green-600 px-4 py-2 text-white shadow-lg">
-          {tDelete("success")}
-        </div>
-      )}
 
       {/* 報告ダイアログ */}
       {!isMyStory && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -7010,6 +7010,11 @@ smol-toml@^1.6.0:
   resolved "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz"
   integrity sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==
 
+sonner@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.7.tgz#810c1487a67ec3370126e0f400dfb9edddc3e4f6"
+  integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
+
 source-map-js@^1.0.1, source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"


### PR DESCRIPTION
## Summary
- デザインシステム整備（ブランドカラー、スペーシング4px統一、テーマトークン化）
- 体感速度改善（スケルトンローダー、sonnerトースト統一、記事タイル軽量化）
- インタラクション改善（いいねアニメーション、コメント楽観的更新、タッチターゲット拡大）
- ナビゲーション改善（ロゴフルリロード修正、教科書リンク追加、記事全域タップ）
- 未ログインユーザー向けフィードゲート（5件で初回表示、閉じても10件ごとに再表示）
- ログアウト後のリダイレクト先をホーム画面に変更

## Test plan
- [ ] ダークモード/ライトモードでブランドカラー(緑)が正しく表示される
- [ ] フィードのスケルトンローダーが初回読み込みで表示される
- [ ] いいねタップで即座に反映 + バウンスアニメーション
- [ ] コメント投稿で即座にリストに追加される
- [ ] 未ログイン状態で5件スクロール後にCTAモーダル表示
- [ ] CTAモーダルのバツで閉じ→追加10件で再表示
- [ ] サイドバーのQuitMateロゴクリックでフルリロードしない
- [ ] ログアウト後にホーム画面(/stories/habits/all)に遷移

🤖 Generated with [Claude Code](https://claude.com/claude-code)