### PR TITLE
perf(web): タイムラインのCLS対策とスケルトン/アバター調整

### DIFF
--- a/apps/web/src/app/(main)/articles/loading.tsx
+++ b/apps/web/src/app/(main)/articles/loading.tsx
@@ -1,0 +1,19 @@
+import { ArticleListSkeleton } from "@/features/articles/ui/article-tile-skeleton";
+
+/**
+ * /articles のページ遷移時ローディング。
+ * (main)/loading.tsx は stories 用の Skeleton を返すため、
+ * articles にはこちらを優先的に用意して横幅/上余白を実ページに揃える。
+ */
+export default function Loading() {
+  return (
+    <>
+      {/* page.tsx の Header (sticky h-14) と同じサイズのプレースホルダ */}
+      <div className="border-border bg-background/80 sticky top-0 z-20 h-14 border-b backdrop-blur-sm" />
+      {/* page.tsx の <main className="p-3 sm:p-5"> と同じ padding */}
+      <main className="p-3 sm:p-5">
+        <ArticleListSkeleton />
+      </main>
+    </>
+  );
+}

--- a/apps/web/src/app/(main)/articles/page.tsx
+++ b/apps/web/src/app/(main)/articles/page.tsx
@@ -2,13 +2,13 @@ import { Logo } from "@quitmate/ui";
 import { Suspense } from "react";
 
 import { Header } from "@/components/layout/header";
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { getCurrentUserUsername } from "@/lib/utils/page-helpers";
 import { fetchProfileByUsername } from "@/features/profiles/data/data";
 
 import { fetchArticles } from "@/features/articles/data/data";
 
 import { ArticleList } from "@/features/articles/ui/article-list";
+import { ArticleListSkeleton } from "@/features/articles/ui/article-tile-skeleton";
 
 export default async function Page() {
   // ヘッダー用のプロフィール情報
@@ -28,11 +28,11 @@ export default async function Page() {
         }
         currentUserProfile={currentUserProfile}
       />
-      <Suspense fallback={<LoadingSpinner fullHeight />}>
-        <div className="p-3 sm:p-5">
+      <main className="p-3 sm:p-5">
+        <Suspense fallback={<ArticleListSkeleton />}>
           <ArticleList fetchArticlesFunc={fetchArticles} />
-        </div>
-      </Suspense>
+        </Suspense>
+      </main>
     </>
   );
 }

--- a/apps/web/src/app/(main)/loading.tsx
+++ b/apps/web/src/app/(main)/loading.tsx
@@ -2,9 +2,20 @@ import { StoryListSkeleton } from "@/features/stories/ui/story-tile-skeleton";
 
 /**
  * サイドバー付きページ用のローディング
- * サイドバーとヘッダーはlayout.tsxで維持されるため、
- * このローディングはコンテンツ部分のみに適用される
+ * サイドバーとレイアウト骨格は (main)/layout.tsx が維持するが、
+ * 各 page.tsx が持つ Header と <main> の padding はこの loading.tsx が
+ * 代替として出す必要がある。実ページと同じ横幅/上余白にして、
+ * 遷移時のスケルトン→本体差し替えのズレを抑える。
  */
 export default function Loading() {
-  return <StoryListSkeleton />;
+  return (
+    <>
+      {/* page.tsx の Header (sticky h-14) と同じサイズのプレースホルダ */}
+      <div className="border-border bg-background/80 sticky top-0 z-20 h-14 border-b backdrop-blur-sm" />
+      {/* page.tsx の <main className="p-3 sm:p-5"> と同じ padding */}
+      <main className="p-3 sm:p-5">
+        <StoryListSkeleton />
+      </main>
+    </>
+  );
 }

--- a/apps/web/src/app/(main)/stories/habits/[category]/page.tsx
+++ b/apps/web/src/app/(main)/stories/habits/[category]/page.tsx
@@ -1,16 +1,17 @@
 import { notFound } from "next/navigation";
-import { Suspense } from "react";
-import { getTranslations } from "next-intl/server";
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { Header } from "@/components/layout/header";
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
 
+import { getQueryClient } from "@/app/get-query-client";
 import { createClient } from "@/lib/supabase/server";
 import { HabitCategoryName } from "@/lib/types";
 import { CATEGORY_ICONS } from "@/lib/categories";
 import { getCurrentUserHabits } from "@/lib/utils/page-helpers";
 import { fetchProfileByUsername } from "@/features/profiles/data/data";
 import { getCurrentUserUsername } from "@/lib/utils/page-helpers";
+import { prefetchStoriesInfinite } from "@/features/stories/data/prefetch";
 
 import { StoryListInfinite } from "@/features/stories/ui/story-list-infinite";
 import { StoriesTabHeader } from "@/features/stories/ui/stories-tab-header";
@@ -80,6 +81,20 @@ export default async function Page(props: PageProps) {
     ? await fetchProfileByUsername(currentUserUsername)
     : null;
 
+  // 「カテゴリ」タブのみ、ストーリー1ページ目を SSR で prefetch して
+  // HydrationBoundary 経由で CSR に渡す（CLS/LCP 改善のため）
+  const currentTab = tab ?? "category";
+  const shouldPrefetchStories = !(currentTab === "following" && isLoggedIn);
+
+  const queryClient = getQueryClient();
+  if (shouldPrefetchStories) {
+    const locale = await getLocale();
+    await prefetchStoriesInfinite(queryClient, {
+      category: habitCategory,
+      locale,
+    });
+  }
+
   return (
     <>
       <Header
@@ -112,48 +127,19 @@ export default async function Page(props: PageProps) {
 
       {/* 投稿リスト */}
       <main className="p-3 sm:p-5">
-        <Suspense fallback={<LoadingSpinner />}>
-          <CategoryPageContent
-            category={category}
-            tab={tab}
-            isLoggedIn={isLoggedIn}
-            userId={user?.id}
-            habits={habits}
-          />
-        </Suspense>
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          {currentTab === "following" && isLoggedIn ? (
+            <FollowingStoryList habits={habits} currentUserId={user?.id} />
+          ) : (
+            <StoryListInfinite
+              category={habitCategory}
+              isLoggedIn={isLoggedIn}
+              habits={habits}
+              currentUserId={user?.id}
+            />
+          )}
+        </HydrationBoundary>
       </main>
-    </>
-  );
-}
-
-async function CategoryPageContent({
-  category,
-  tab,
-  isLoggedIn,
-  userId,
-  habits,
-}: {
-  category: string;
-  tab?: string;
-  isLoggedIn: boolean;
-  userId?: string;
-  habits?: import("@/lib/types").HabitTileDto[];
-}) {
-  const habitCategory = capitalizeCategory(category);
-  const currentTab = tab ?? "category";
-
-  return (
-    <>
-      {currentTab === "following" && isLoggedIn ? (
-        <FollowingStoryList habits={habits} currentUserId={userId} />
-      ) : (
-        <StoryListInfinite
-          category={habitCategory}
-          isLoggedIn={isLoggedIn}
-          habits={habits}
-          currentUserId={userId}
-        />
-      )}
     </>
   );
 }

--- a/apps/web/src/app/get-query-client.ts
+++ b/apps/web/src/app/get-query-client.ts
@@ -1,0 +1,35 @@
+import { QueryClient, defaultShouldDehydrateQuery, isServer } from "@tanstack/react-query";
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // SSRではprefetchしているので、クライアントで再フェッチしない
+        staleTime: 60 * 1000, // 1分間はstale状態にならない
+        refetchOnWindowFocus: false,
+      },
+      dehydrate: {
+        // ストリーミング時に pending 状態のクエリも dehydrate する
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) || query.state.status === "pending",
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+/**
+ * Next.js App Router 向けの QueryClient 取得関数。
+ * - Server: 毎回新規作成（リクエスト間でデータがリークしないように）
+ * - Browser: シングルトンを再利用（Suspense 中の再生成を防ぐ）
+ *
+ * @see https://tanstack.com/query/v5/docs/framework/react/examples/nextjs-app-prefetching
+ */
+export function getQueryClient() {
+  if (isServer) {
+    return makeQueryClient();
+  }
+  if (!browserQueryClient) browserQueryClient = makeQueryClient();
+  return browserQueryClient;
+}

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,21 +1,11 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useState } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+
+import { getQueryClient } from "./get-query-client";
 
 export function QueryProvider({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            // SSRではprefetchしているので、クライアントで再フェッチしない
-            staleTime: 60 * 1000, // 1分間はstale状態にならない
-            refetchOnWindowFocus: false,
-          },
-        },
-      }),
-  );
+  const queryClient = getQueryClient();
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }

--- a/apps/web/src/features/articles/ui/article-tile-skeleton.tsx
+++ b/apps/web/src/features/articles/ui/article-tile-skeleton.tsx
@@ -1,0 +1,61 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * ArticleTile と同じレイアウトでプレースホルダを出す Skeleton。
+ * padding / margin / 角丸 / border は ArticleTile (article-tile.tsx) に合わせている。
+ */
+export function ArticleTileSkeleton() {
+  return (
+    <div className="border-border overflow-hidden rounded-lg border shadow-sm">
+      <div className="p-4 md:p-5">
+        {/* タイトル（h2 text-lg md:text-xl font-bold / line-clamp-2） */}
+        <div className="mb-2 space-y-2">
+          <Skeleton className="h-6 w-full md:h-7" />
+          <Skeleton className="h-6 w-3/4 md:h-7" />
+        </div>
+
+        {/* カテゴリタグ + 日付 */}
+        <div className="mb-2 flex items-center justify-between">
+          <Skeleton className="h-[22px] w-24 rounded-full md:h-7 md:w-28" />
+          <Skeleton className="h-3 w-16 md:h-4 md:w-20" />
+        </div>
+
+        {/* 抜粋（text-sm leading-relaxed / line-clamp-3） */}
+        <div className="mb-3 space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+
+        {/* アクション + 著者情報 */}
+        <div className="flex items-center justify-between">
+          <div className="text-muted-foreground flex gap-4">
+            <div className="flex items-center gap-1">
+              <Skeleton className="size-4 rounded" />
+              <Skeleton className="h-3 w-4" />
+            </div>
+            <div className="flex items-center gap-1">
+              <Skeleton className="size-4 rounded" />
+              <Skeleton className="h-3 w-4" />
+            </div>
+          </div>
+          {/* 著者: UserAvatar size="sm" = size-8 + display_name */}
+          <div className="flex items-center gap-2">
+            <Skeleton className="size-8 rounded-full" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ArticleListSkeleton({ count = 5 }: { count?: number }) {
+  return (
+    <div className="mx-auto max-w-[600px] space-y-2">
+      {Array.from({ length: count }).map((_, i) => (
+        <ArticleTileSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/profiles/ui/user-avatar.tsx
+++ b/apps/web/src/features/profiles/ui/user-avatar.tsx
@@ -11,6 +11,20 @@ type UserAvatarProps = {
   linkable?: boolean;
 };
 
+// Tailwind v4 のスキャナは `size-${n}` の動的生成を拾えないため、
+// クラス名と実寸を静的にマッピングする
+const SIZE_CLASS_MAP = {
+  sm: "size-8",
+  md: "size-10",
+  lg: "size-[72px]",
+} as const;
+
+const SIZE_PX_MAP = {
+  sm: 32,
+  md: 40,
+  lg: 72,
+} as const;
+
 export function UserAvatar({
   username = "unknown",
   displayName,
@@ -19,15 +33,8 @@ export function UserAvatar({
   showUsername = false,
   linkable = true,
 }: UserAvatarProps) {
-  // サイズの値をピクセルに変換
-  const sizeMap = {
-    sm: 32,
-    md: 48,
-    lg: 72,
-  };
-  const pixelSize = sizeMap[size];
-
-  const containerClass = `size-${(pixelSize / 4).toString()} overflow-hidden rounded-full`;
+  const pixelSize = SIZE_PX_MAP[size];
+  const containerClass = `${SIZE_CLASS_MAP[size]} overflow-hidden rounded-full`;
 
   const avatarElement = (
     <div className={containerClass}>

--- a/apps/web/src/features/stories/data/prefetch.ts
+++ b/apps/web/src/features/stories/data/prefetch.ts
@@ -1,0 +1,134 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import { createClient } from "@/lib/supabase/server";
+import { HabitCategoryName, StoryTileDto } from "@/lib/types";
+
+import { PAGE_SIZE, STORY_SELECT_QUERY } from "./constants";
+
+type Page = {
+  stories: StoryTileDto[];
+  hasMore: boolean;
+};
+
+// boundaryTime のキャッシュキー（useInfiniteStories と一致させる必要あり）
+const getBoundaryTimeKey = (category: HabitCategoryName, locale: string) =>
+  ["stories", "boundaryTime", category, locale] as const;
+
+// ストーリー一覧のキャッシュキー（useInfiniteStories と一致させる必要あり）
+const getStoriesInfiniteKey = (category: HabitCategoryName, locale: string) =>
+  ["stories", "category", category, locale] as const;
+
+/**
+ * サーバー側でストーリー1ページを取得する。
+ * useInfiniteStories の queryFn と同じ結果（RPC → detail → いいね状態）を返す。
+ */
+async function fetchStoriesPage(params: {
+  category: HabitCategoryName;
+  locale: string;
+  boundaryTime: string;
+  pageParam: number;
+}): Promise<Page> {
+  const { category, locale, boundaryTime, pageParam } = params;
+  const supabase = await createClient();
+
+  const from = pageParam * PAGE_SIZE;
+  const to = (pageParam + 1) * PAGE_SIZE - 1;
+
+  const languageCode = locale === "ja" || locale === "en" ? locale : "ja";
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { data: storyIdsData, error: rpcError } = await supabase.rpc(
+    "get_ranged_stories_by_habit_including_official_with_language",
+    {
+      input_habit_category_name: category === "All" ? null : category,
+      from_pos: from,
+      to_pos: to,
+      before_timestamp: boundaryTime,
+      input_language_code: languageCode,
+    },
+  );
+
+  if (rpcError || !storyIdsData || storyIdsData.length === 0) {
+    if (rpcError) {
+      console.error("[prefetchStoriesInfinite] RPC error", rpcError);
+    }
+    return { stories: [], hasMore: false };
+  }
+
+  const storyIds = (storyIdsData as { id: string }[]).map((item) => item.id);
+
+  const { data: stories, error: storiesError } = await supabase
+    .from("stories")
+    .select(STORY_SELECT_QUERY)
+    .in("id", storyIds);
+
+  if (storiesError || !stories) {
+    console.error("[prefetchStoriesInfinite] stories fetch error", storiesError);
+    return { stories: [], hasMore: false };
+  }
+
+  // RPC で返ってきた順序を保持
+  const storyMap = new Map(stories.map((s) => [s.id, s]));
+  const ordered = storyIds
+    .map((id) => storyMap.get(id))
+    .filter((s): s is NonNullable<typeof s> => s !== undefined) as StoryTileDto[];
+
+  // いいね状態（ログイン時のみ）
+  let storiesWithLikes: StoryTileDto[] = ordered;
+  if (user && ordered.length > 0) {
+    const { data: likeData } = await supabase.rpc("get_has_liked_by_story_ids", {
+      p_story_ids: ordered.map((s) => s.id),
+      p_user_id: user.id,
+    });
+
+    const likeMap = new Map(
+      (likeData as { story_id: string; has_liked: boolean }[])?.map((l) => [
+        l.story_id,
+        l.has_liked,
+      ]) ?? [],
+    );
+
+    storiesWithLikes = ordered.map((s) => ({
+      ...s,
+      isLikedByMe: likeMap.get(s.id) ?? false,
+    }));
+  }
+
+  return {
+    stories: storiesWithLikes,
+    hasMore: storyIdsData.length === PAGE_SIZE,
+  };
+}
+
+/**
+ * ストーリー一覧の1ページ目を SSR で prefetch して QueryClient に入れる。
+ * - boundaryTime はここで固定し、setQueryData でキャッシュに入れる
+ *   （CSR 側の useInfiniteStories が同じキーから読み取る）
+ * - 失敗してもページ描画は継続（空状態でクライアントが再取得する）
+ */
+export async function prefetchStoriesInfinite(
+  queryClient: QueryClient,
+  params: { category: HabitCategoryName; locale: string },
+) {
+  const { category, locale } = params;
+  const boundaryTime = new Date().toISOString();
+
+  // CSR 側のフックが getBoundaryTime() で読み取るキーに合わせて保存
+  queryClient.setQueryData(getBoundaryTimeKey(category, locale), boundaryTime);
+
+  try {
+    await queryClient.prefetchInfiniteQuery({
+      queryKey: getStoriesInfiniteKey(category, locale),
+      queryFn: ({ pageParam }: { pageParam: number }) =>
+        fetchStoriesPage({ category, locale, boundaryTime, pageParam }),
+      initialPageParam: 0,
+      staleTime: Infinity,
+    });
+  } catch (e) {
+    // prefetch の失敗はページ描画を止めない（CSR 側で再取得される）
+    console.error("[prefetchStoriesInfinite] prefetch failed", e);
+  }
+}

--- a/apps/web/src/features/stories/ui/story-tile-skeleton.tsx
+++ b/apps/web/src/features/stories/ui/story-tile-skeleton.tsx
@@ -1,26 +1,52 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
+/**
+ * StoryTile と同じレイアウト構造でプレースホルダを出すためのSkeleton。
+ * padding/margin/gap は StoryTile (story-tile.tsx) に完全に合わせている。
+ */
 export function StoryTileSkeleton() {
   return (
-    <div className="border-border flex border-b py-4">
-      <div className="mr-3">
-        <Skeleton className="size-12 rounded-full" />
-      </div>
-      <div className="flex-1">
-        <div className="mb-1 flex items-center gap-2">
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-3 w-16" />
+    <div className="border-border border-b">
+      <div className="flex px-0 py-4">
+        {/* アバター部分 (StoryTile の UserAvatar size="md" = size-10) */}
+        <div className="mr-3">
+          <Skeleton className="size-10 rounded-full" />
         </div>
-        <div className="mb-2">
-          <Skeleton className="h-5 w-20 rounded-full" />
-        </div>
-        <div className="mb-3 space-y-2">
-          <Skeleton className="h-4 w-full" />
-          <Skeleton className="h-4 w-3/4" />
-        </div>
-        <div className="flex gap-4">
-          <Skeleton className="h-4 w-10" />
-          <Skeleton className="h-4 w-10" />
+
+        {/* メインコンテンツ */}
+        <div className="flex-1">
+          {/* ヘッダー行: 名前 + @user + 日付 （右端にメニューボタン領域） */}
+          <div className="mb-1 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-4 w-24 md:h-5 md:w-28" />
+              <Skeleton className="h-3 w-16 md:h-4 md:w-20" />
+              <Skeleton className="h-3 w-10 md:h-4 md:w-12" />
+            </div>
+          </div>
+
+          {/* カテゴリタグ行（Tag: px-2 py-0.5 text-xs md:px-3 md:py-1 md:text-sm） */}
+          <div className="mb-2 flex items-center gap-2">
+            <Skeleton className="h-[22px] w-28 rounded-full md:h-7 md:w-32" />
+          </div>
+
+          {/* 本文（StoryTile の text-sm md:text-base / whitespace-pre-wrap を模倣、3行想定） */}
+          <div className="mb-3 space-y-2">
+            <Skeleton className="h-4 w-full md:h-5" />
+            <Skeleton className="h-4 w-full md:h-5" />
+            <Skeleton className="h-4 w-4/5 md:h-5" />
+          </div>
+
+          {/* アクション行: コメント数 / いいね数 */}
+          <div className="text-muted-foreground flex gap-4 md:gap-6">
+            <div className="flex items-center gap-1">
+              <Skeleton className="size-4 rounded md:size-5" />
+              <Skeleton className="h-3 w-4 md:h-4 md:w-6" />
+            </div>
+            <div className="flex items-center gap-1">
+              <Skeleton className="size-4 rounded md:size-5" />
+              <Skeleton className="h-3 w-4 md:h-4 md:w-6" />
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 背景

quitmate.app の CLS が **0.715**（Google基準 0.1 以下）と深刻で、ランキングに悪影響が出ていたため対策。主因は `/stories/habits/[category]` がクライアントサイドでストーリーを取得していて、skeleton→実データ差し替えで大きくレイアウトがズレていた点。

## 主な変更

### CLS 対策 (本丸)
- `/stories/habits/[category]` に **SSR prefetch + HydrationBoundary** を導入
  - `get-query-client.ts`: TanStack Query v5 公式推奨パターン (isServer 分岐 + 遅延 dehydration)
  - `features/stories/data/prefetch.ts`: サーバー側 fetcher + `prefetchInfiniteQuery` helper
  - `page.tsx` で 1 ページ目を prefetch → dehydrate → Client の `useInfiniteStories` が自動で hydrated data を拾う
  - 初回 HTML に実ストーリー本文が入るので skeleton が一瞬も出ない
  - LCP にも効く

### Skeleton 品質改善
- `StoryTileSkeleton`: 実タイルと同じレイアウト構造 (padding/gap/flex/レスポンシブ h-4→md:h-5 まで揃える)
- `ArticleTileSkeleton` を新設 (これまで articles 側は skeleton が存在せず、スピナーだった)
- `(main)/loading.tsx` / `articles/loading.tsx`: 実ページと同じ `<main className="p-3 sm:p-5">` + sticky Header プレースホルダを追加。ページ遷移時の横幅/上余白のズレを解消

### 付随する修正
- `UserAvatar` の動的 Tailwind クラス (`size-\${pixelSize/4}`) を静的マップに変更
  - `size-18` が Tailwind デフォルトに存在せず無効化されていた問題も解消
- `UserAvatar size=\"md\"` を **48px → 40px** に変更 (X のタイムライン準拠)

## 確認方法

1. \`yarn dev:web:prod\` (or dev) で \`/stories/habits/all\` を開く
2. view-source で HTML に実ストーリー本文が含まれていることを確認
3. サイドバーから別カテゴリに遷移して skeleton の横幅/上余白が実ページと揃っていることを確認
4. \`/articles\` でも同様のUXになっていることを確認

## デプロイ後の計測

本番反映後に https://pagespeed.web.dev/ で \`quitmate.app\` を計測し、CLS が 0.1 以下になっていることを確認する。Search Console の Core Web Vitals は集計反映まで 2〜4 週間かかる点に注意。

🤖 Generated with [Claude Code](https://claude.com/claude-code)