### PR TITLE
fix(web): robots.txt 生成とLighthouse a11y指摘を修正

### DIFF
--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from "next";
+
+// 1日ごとに再生成（sitemap.ts と同じ）
+export const revalidate = 86400;
+
+export default function robots(): MetadataRoute.Robots {
+  const url = process.env.NEXT_PUBLIC_URL;
+
+  // sitemap.ts と挙動を揃える: Vercel 環境では env 必須、それ以外では最小の robots を返す
+  if (!url) {
+    if (process.env.VERCEL) {
+      throw new Error("NEXT_PUBLIC_URL is not set");
+    }
+    return {
+      rules: [{ userAgent: "*", allow: "/" }],
+    };
+  }
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        // 認証/個人設定/投稿フォーム等クローラに見せる必要のないパスを除外
+        disallow: ["/auth/", "/settings/", "/stories/create", "/habits/register"],
+      },
+    ],
+    sitemap: `${url}/sitemap.xml`,
+  };
+}

--- a/apps/web/src/components/ui/login-prompt-dialog.tsx
+++ b/apps/web/src/components/ui/login-prompt-dialog.tsx
@@ -15,6 +15,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 type LoginPromptDialogProps = {
   children: ReactNode;
@@ -32,8 +33,14 @@ export function LoginPromptDialog({ children, className, type = "story" }: Login
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild className={className}>
-        {children}
+      {/*
+       * 呼び出し側から非ボタン要素 (div 等) を children で受け取っても
+       * aria 属性が role と整合するよう、trigger は必ず <button> にする。
+       */}
+      <DialogTrigger asChild>
+        <button type="button" className={cn("inline-flex", className)}>
+          {children}
+        </button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-md">
         <DialogHeader className="items-center">

--- a/apps/web/src/features/profiles/ui/user-avatar.tsx
+++ b/apps/web/src/features/profiles/ui/user-avatar.tsx
@@ -55,8 +55,12 @@ export function UserAvatar({
 
   // リンク付きかどうかで要素を分ける
   if (linkable && username !== "unknown") {
+    // showUsername=true の時はリンク内に display_name / @user のテキストがあるので
+    // aria-label を付けるとスクリーンリーダがそちらを読まなくなる。
+    // accessible name が画像の alt しか無い showUsername=false のときだけ補う。
+    const ariaLabel = showUsername ? undefined : `${displayName ?? username}のプロフィール`;
     return (
-      <Link href={`/${username}`} className="flex items-center gap-2">
+      <Link href={`/${username}`} className="flex items-center gap-2" aria-label={ariaLabel}>
         {avatarElement}
         {userInfoElement}
       </Link>


### PR DESCRIPTION
## 背景

Google Search Console で以下が検出されたため対応。

1. **robots.txt が無効**: `/robots.txt` リクエストが `/[user_name]` の dynamic route に飲み込まれて HTML (`User not found | QuitMate`) が返っていた
2. **aria-* 属性が role と一致しない**: Lighthouse / accessibility 監査で指摘
3. **リンクテキストなし**: UserAvatar 内の Link が DefaultAvatar 利用時に accessible name を持たない

## 変更内容

### `app/robots.ts` 新設
- Next.js App Router の MetadataRoute.Robots パターンで \`/robots.txt\` を生成
- sitemap.ts と同じ \`revalidate: 86400\` / \`NEXT_PUBLIC_URL\` 必須の挙動
- Disallow: \`/auth/\`, \`/settings/\`, \`/stories/create\`, \`/habits/register\`
- \`host\` フィールドは Google が解釈しない (Yandex 専用, 非推奨) ため付けない

### \`login-prompt-dialog.tsx\`
\`DialogTrigger asChild\` の children を \`<button type=\"button\">\` でラップ。呼び出し側から \`<div>\` を渡しても aria-haspopup / aria-expanded が button role と整合するように修正。\`className\` は \`cn(\"inline-flex\", className)\` で元の \`cursor-pointer\` と \`inline-flex\` を両立。

### \`user-avatar.tsx\`
Link に accessible name を追加。ただし \`showUsername=true\` の時はリンク内にテキスト（表示名 + @user）があるため aria-label は付けない (SR がそちらを読まなくなるのを回避)。\`showUsername=false\` 時だけ \`{displayName}のプロフィール\` を付与。

## ビルド確認

\`\`\`
├ ○ /robots.txt                                                1d      1y
\`\`\`

静的ルートとして正しく登録されることをビルドログで確認済み。

## 確認方法

- 本番デプロイ後、\`https://quitmate.app/robots.txt\` が \`User-agent: *\` で始まる text/plain を返すか確認
- Search Console で \"robots.txt のテスト\" を再実行 → 形式エラーが消えるはず
- Lighthouse Accessibility で aria-* 関連の指摘が消えるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)