### PR TITLE
docs(lp): /learn 英語版 usage-pattern-b-title も Important 表記に統一

### DIFF
--- a/apps/lp/src/i18n/messages/en.json
+++ b/apps/lp/src/i18n/messages/en.json
@@ -244,7 +244,7 @@
             "usage-guide-intro": "There is no single right way to read this book. Pick the pattern that fits your situation.",
             "usage-pattern-a-title": "Pattern A: Read in order (default)",
             "usage-pattern-a-body": "Start from Chapter 1 and read in order. The book is designed so that reading sequentially lets your understanding build up step by step. One chapter a day or one a week is fine — go at your own pace.",
-            "usage-pattern-b-title": "Pattern B: Read only the two essential chapters",
+            "usage-pattern-b-title": "Pattern B: Read only the two chapters marked Important",
             "usage-pattern-b-body": "If you have no time, or if you are in crisis, just these two chapters are enough to start: Chapter 7 (Cut off access to money) and Chapter 9 (When you want to die: a safety plan).",
             "usage-pattern-c-title": "Pattern C: Read by situation",
             "usage-pattern-c-body": "Pick chapters based on what you face right now: cravings, payday anxiety, suicidal thoughts, family conversations, debt fears.",


### PR DESCRIPTION
## Summary
- PR #199 で日本語側を「重要マークの2章」に変更したのに合わせて、英語側も `essential` → `marked Important` に揃える
- 変更: `Pattern B: Read only the two essential chapters` → `Pattern B: Read only the two chapters marked Important`

## Test plan
- [ ] `/en/learn/quit-gambling-today/about` でパターンBの文言が更新されていることを確認
- [ ] `Important` バッジとの言葉の整合が取れていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)