### PR TITLE
docs(lp): /learn「あと1万が止まらない」英語版全27章を追加

### DIFF
--- a/apps/lp/src/content/learn/en/quit-gambling-today/about.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/about.md
@@ -1,0 +1,66 @@
+---
+category: "gambling"
+part: "A"
+chapter: 0
+title: "About This Book"
+required: false
+excerpt: "Maybe you searched for a way to stop gambling. Maybe someone in your family told you to read something, so you opened this. Maybe you're reading it during another 'this is the last time.' If gambling is causing problems in your life, give this book a little of your time."
+updatedAt: "2026-04-22"
+---
+Maybe you searched for a way to stop gambling.
+Maybe someone in your family told you to read something, so you opened this.
+Maybe you're reading it during another "this is the last time."
+If gambling is causing problems in your life, give this book a little of your time.
+
+The book has 26 chapters. It was written using medical research and actual data from [QuitMate](https://www.quitmate.app/), an app-based recovery community for people with addictions.
+It covers how the gambling brain works, managing money, dealing with debt, rebuilding family relationships, and a 30-day recovery plan.
+
+---
+
+## How to read this book
+
+You don't have to read it in order. Start wherever something catches your eye.
+
+**You keep blaming yourself**
+- [Chapter 1: Gambling Addiction Is Not a Weak Will](/en/learn/quit-gambling-today/not-willpower/)
+- [Chapter 2: The Dopamine Trap](/en/learn/quit-gambling-today/dopamine-trap/)
+
+**You want to stop but can't**
+- [Chapter 9: What a Craving Is and How to Ride It Out](/en/learn/quit-gambling-today/craving-basics/)
+- [Chapter 11: HALT](/en/learn/quit-gambling-today/halt/)
+
+**Money disappears as soon as you have it**
+- [Chapter 6: Cutting Off Access to Money](/en/learn/quit-gambling-today/money-access/)
+- [Chapter 7: Surviving Payday](/en/learn/quit-gambling-today/payday-survival/)
+
+**Your family found out, or you have to tell them**
+- [Chapter 19: Family Relationships](/en/learn/quit-gambling-today/family/)
+
+If you'd rather read in order, the chapters are arranged so that understanding builds slowly from one to the next.
+
+- **Part A (Chapters 1–5)**: Understanding what's happening in your brain
+- **Part B (Chapters 6–10)**: Things you can start doing today
+- **Part C (Chapters 11–14)**: Finding and handling your triggers
+- **Part D (Chapters 15–20)**: Debt, family, and mental health
+- **Part E (Chapters 21–26)**: Turning recovery into a system
+
+---
+
+## What this book does not cover
+
+This book focuses on what you need in the first 30 days of recovery.
+The following are outside its scope and belong with clinicians and specialists.
+
+- Detailed cognitive behavioral therapy practice
+- Trauma treatment
+- Medication
+- Inner workings of specific gambling machines or platforms
+- Support for family members (family groups, Gam-Anon, and similar)
+
+---
+
+Gambling addiction is not something you develop because your will is weak.
+It's a problem in how the brain works, and it's recognized as a medical disorder.
+
+If you're telling yourself "something is wrong with me," start with [Chapter 1](/en/learn/quit-gambling-today/not-willpower/).
+You may think about it differently afterward.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/asking-for-help.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/asking-for-help.md
@@ -1,0 +1,217 @@
+---
+category: "gambling"
+part: "B"
+chapter: 10
+title: "How to Ask for Help"
+required: false
+excerpt: "10 p.m. Scrolling through my text messages. Three weeks ago I relapsed again, and I've been sliding ever since. I haven't told anyone. I don't even know who to tell, or what to say."
+updatedAt: "2026-04-22"
+---
+10 p.m.
+Scrolling through my text messages.
+Three weeks ago I relapsed. Since then I've been going back, and I haven't told anyone.
+I don't know who to tell or what to say. I don't even know what I'm asking for.
+
+My brother. No. He'll lecture me.
+A friend from college. No. We haven't talked in five years.
+My wife. She already knows the last round, and I can't put more on her.
+I stopped scrolling and put the phone face down.
+I didn't tell anyone today.
+I won't tomorrow either.
+
+"Asking for help" is the hardest thing.
+I don't know how.
+I don't even know what I'd be asking for.
+
+---
+
+## Asking for help is hard
+
+People with gambling addiction find it especially hard to ask for help.
+There are many reasons.
+
+- **Shame**: "I can't believe I'd have to say this out loud"
+- **Pride**: "I should be able to handle this on my own"
+- **Past failures**: you've let the same people down before, you can't ask them again
+- **Can't find words**: trying to describe your state makes you panic
+- **You don't know what to ask for**: solutions? money? just someone to listen? you haven't worked it out
+
+These pile up, and the result is "I can't tell anyone."
+Isolation, and the addiction deepening inside it.
+
+"Can't ask for help" is not a personality problem.
+It's a symptom of the illness.
+
+---
+
+## What "asking for help" actually means
+
+A common misconception: "asking for help" doesn't mean "expecting the other person to solve your problem."
+
+- Not paying off your debt for you
+- Not curing you
+- Not giving you answers
+
+What it is:
+
+**Taking what's inside you, putting it into words, and letting someone else hear it.**
+
+That's the core of asking for help.
+Often the other person has no answers. That's fine.
+The act of putting your state into words and having someone hear it is the recovery work.
+
+"Just be heard." That's often the most important help.
+
+---
+
+## Who to ask
+
+### What to look for
+
+Look for:
+
+- Someone who doesn't lecture
+- Someone who doesn't bring up the past
+- Someone who can let you finish a sentence
+- Someone who doesn't default to "this is your fault"
+- Someone who doesn't rush to solve
+
+Avoid:
+
+- Someone who lectures
+- Someone who defaults to blame
+- Someone who always wants to fix
+- Someone who keeps relitigating the past
+- Someone who redirects to their own story
+
+Sometimes nobody in your family fits. That's common.
+Go outside the family then. You're not wrong to do that.
+
+### Candidates
+
+- A trusted family member or relative
+- An old friend (even if you haven't talked in a while)
+- A sponsor or peer from GA (Gamblers Anonymous)
+- Medical professionals
+- A support group
+- A community mental health center staff member
+- A therapist or counselor
+- A credit counselor or legal aid lawyer for debt-related issues
+
+"Nobody" is never actually true. Even if family and friends don't fit, medical and public services always exist.
+
+---
+
+## Examples of the first thing to say
+
+"What do I even say" is often the biggest wall.
+Here are examples by situation.
+Use them as-is, or rewrite in your own voice.
+
+### To family
+
+- "I need to talk to you about something. Do you have a minute?"
+- "There's something I haven't been honest about. Can you listen?"
+- "I've been struggling with gambling. I want us to go to a professional together"
+- "I can't do this on my own. I need help"
+
+### To a friend
+
+- "It's been a while. Can I talk to you about something?"
+- "I've been struggling with an addiction. Could you just listen?"
+- "I've been hitting a wall doing this alone. Do you have time for a call?"
+
+### To a helpline, GA, or a treatment line
+
+- "I'm calling about a gambling problem, I'd like to talk to someone"
+- "I saw your website, this is my first time calling"
+- "Can you walk me through how to make an appointment?"
+- "I don't know where to start. Can you help me figure that out?"
+
+### To a trusted coworker
+
+- "I need to talk about something personal. Not work related. Is now okay?"
+
+---
+
+## What to say on the first call or visit
+
+You don't need to know what to say.
+At the start, these are enough:
+
+1. Your name
+2. "I have a gambling problem"
+3. "This is my first call"
+4. "I don't know what to do"
+
+That's it. No details required.
+The person on the other end does this for a living. They'll ask questions.
+You answer their questions. That's the first conversation.
+
+You don't have to explain the whole situation perfectly.
+You can stumble on words. You can go quiet. They'll hold the conversation with you.
+
+---
+
+## Small steps if "I can't talk" is stuck
+
+Don't wait for perfect words.
+Don't wait for the perfect person.
+Don't wait for the right time.
+
+"Someday" and "once things calm down" never arrive.
+
+Start with the smallest possible step:
+
+- Send one line over text
+- Email "can we talk?"
+- Open the support group's website (you don't have to read it)
+- Look up the schedule for a local GA meeting
+- Save a treatment provider's number in your phone
+- Write a helpline number on a piece of paper
+
+These are steps before "asking for help."
+Keep doing the smallest step, and one day, you actually make the call.
+
+---
+
+## If they say no
+
+You gathered courage to reach out, and the other person was busy or couldn't show up.
+This hurts. Really.
+A lot of people decide here: "I'm never asking anyone again."
+
+- If one person can't, move to the next
+- "I'm busy" and "bad timing" are about them, not about you
+- It's not a rejection of you personally
+- Have at least three names ready
+
+Having options in advance protects you from collapsing when one person can't answer.
+
+---
+
+## With professionals, don't hold back
+
+Clinicians, counselors, helpline staff, GA sponsors.
+For these people, being asked for help is their job.
+
+"Am I bothering them?" "Are they busy?" "Is my problem too small?"
+These hesitations belong with family and friends.
+They don't belong with professionals.
+
+For them, the harder part of the job is when people don't reach out.
+Their work is specifically about moving people who find it hard to ask.
+So lean on them. No need to hold back.
+
+You can open a call by asking "am I bothering you?" if you need to.
+The answer almost always comes back "not at all."
+
+
+## References
+
+- Suurvali, H., Cordingley, J., Hodgins, D.C., & Cunningham, J. (2009). Barriers to seeking help for gambling problems: A review of the empirical literature. *Journal of Gambling Studies*, 25(3), 407-424.
+- Pulford, J., Bellringer, M., Abbott, M., Clarke, D., Hodgins, D., & Williams, J. (2009). Reasons for seeking help for a gambling problem: The experiences of gamblers who have sought specialist assistance and the perceptions of those who have not. *Journal of Gambling Studies*, 25(1), 19-32.
+- Cunningham, J.A. (2005). Little use of treatment among problem gamblers. *Psychiatric Services*, 56(8), 1024-1025.
+- Hodgins, D.C., & el-Guebaly, N. (2000). Natural and treatment-assisted recovery from gambling problems: a comparison of resolved and active gamblers. *Addiction*, 95(5), 777-789.
+- Gainsbury, S., Hing, N., & Suhonen, N. (2014). Professional help-seeking for gambling problems: Awareness, barriers and motivators for treatment. *Journal of Gambling Studies*, 30(2), 503-519.
+- Gamblers Anonymous. http://www.gamblersanonymous.org/

--- a/apps/lp/src/content/learn/en/quit-gambling-today/brain-recovers.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/brain-recovers.md
@@ -1,0 +1,185 @@
+---
+category: "gambling"
+part: "A"
+chapter: 4
+title: "The Brain Recovers"
+required: false
+excerpt: "6 a.m. I get up, open the blinds, and see the lit-up casino sign across the freeway."
+updatedAt: "2026-04-22"
+---
+6 a.m. I get up, open the blinds, and see the lit-up casino sign across the freeway.
+
+A year ago, just seeing that sign pulled me toward the car.
+Six months ago, my body didn't move, but there was a pull, a brief tug.
+Three months ago, I didn't feel anything, but I noticed my eyes had followed it.
+This morning, I registered the sign, thought "huh," and went to put on coffee.
+
+I don't know what's happening, exactly.
+But something is definitely shrinking.
+Maybe this is what "the brain coming back" means.
+
+---
+
+## Your brain changes by design
+
+Your brain is not a fixed machine. It physically changes based on how you use it.
+The term for this is neuroplasticity.
+
+Gamble for years, and your brain shifts into a "gambling brain."
+Stop, and it shifts the other direction. It slowly moves away from the gambling brain.
+
+This isn't optimism. It's been shown in animal studies and in human brain imaging: sustained abstinence allows brain function to recover in stages.
+
+The point isn't "it changed, so it's stuck." The point is "it changes by nature, so it can also change back."
+
+---
+
+## A rough timeline
+
+Recovery in the addicted brain tends to follow a loose timeline. The variation between people is large, so read this as a rough map, not a schedule.
+
+### First 72 hours
+
+The most dangerous stretch.
+
+- Frequent cravings
+- Insomnia, irritability, anxiety, restlessness
+- Moments where "I shouldn't have stopped" hits hard
+- This is when the most people relapse
+
+The biggest weapon in the first 72 hours is physically cutting off access. Not willpower. Block the ability to get money and the ability to gamble. Practical steps are in [Chapter 6](/en/learn/quit-gambling-today/money-access/).
+
+### Week 1
+
+Cravings peak around this time.
+- Your body calms down a bit
+- Appetite starts to come back
+- Sleep partly returns
+- But your mood stays flat, "nothing feels good"
+
+This is the start of the "liking is thin" period described in the dopamine trap chapter.
+Some people relapse here, because "I stopped and it's not even fun" kicks in.
+
+### Month 1
+
+Cravings come less often.
+- Sometimes "this is a pain" wins out over "I want to"
+- Sleep and appetite are mostly normal
+- Mood is still flat
+
+Some people at this point decide they're "cured" and drop their guard. That's dangerous.
+The brain is only beginning to change. A strong cue can bring the craving back instantly.
+
+### Month 3
+
+Changes start to show up on brain imaging.
+- Dopamine overrelease is quieting down
+- The brakes (prefrontal cortex) start working again
+- You can start feeling a small amount of "liking" from food, exercise, and time with people
+
+Cravings can still hit hard out of nowhere at this point.
+The brain's conditioning to cues (sounds, logos, smells) takes longer to undo than basic function.
+Slot sounds or the smell of a casino can still produce a response here.
+
+### Month 6
+
+A lot of people describe this as "the world looks slightly different."
+- Interest in things other than gambling comes back
+- Attention returns to hobbies, work, family
+- "I've actually stopped" becomes something you can feel
+
+Many people only realize here that time has opened up in their lives again.
+Cravings still come when the cues are strong.
+
+### Year 1
+
+The brain changes are starting to settle.
+- Most people's lives have shifted as a whole
+- You no longer want to go back to who you were
+- "I stopped" becomes something you don't actively think about
+
+You get closer to the "huh, there's a casino sign" state from the opening of this chapter.
+Relapse is still possible if you drop your guard. Plenty of people who hit the one-year mark relapse shortly after.
+
+### Year 2 and beyond
+
+Structural brain changes continue on a deeper level.
+- Brain imaging of people who've abstained five or more years has been shown to move close to a pre-addicted state
+- "Not gambling" becomes "the way I live"
+- Some people's cravings disappear entirely; others still get occasional ones
+
+Even here, we don't say "cured." Addiction is not something you get rid of. It's something you learn to keep in a managed state.
+That said, the lives of people who've been here for years look nothing like their gambling years.
+
+---
+
+## Getting through the "I feel nothing" period
+
+Almost everyone in recovery hits one specific wall.
+**The period where nothing feels good.**
+
+In the first weeks to months after you stop, you don't feel pleasure from things that used to bring it. Food tastes neutral. Days off feel long and empty. You're with your family but only half your head is present.
+
+This is a brain issue, not a character issue.
+The addicted brain has strong "wanting" and weak "liking." Stopping gambling doesn't instantly restore "liking." The circuits need time.
+
+This is where a lot of people think "if quitting is this empty, what's the point," and relapse.
+
+Things to know for getting through it:
+
+- Pleasure doesn't come back "suddenly one day." It comes back slowly
+- Early on, it's so thin you won't notice
+- By the time you notice it's coming back, it's already been coming back for a while
+- The only thing you can do is wait
+- While waiting, keep doing the other things (move, see people, make things, sleep, eat, get outside)
+
+Don't expect pleasure to come back quickly. Knowing in advance that "there's a period where nothing feels good" is what gets you through that period.
+
+---
+
+## Recovery isn't a straight line
+
+Recovery doesn't look like a steadily rising curve. It looks like waves moving forward.
+
+Good days, bad days.
+A month of feeling solid, then three bad days in a row.
+Around the six-month mark you'll think "I'm completely fine," and then a hard craving will hit.
+This happens to everyone.
+
+Some people relapse. Relapse doesn't end it. We'll go deeper into "relapse is not failure" in a later chapter, but the same thing applies on the recovery timeline too.
+
+Recovery isn't defined as "never relapsing." It's defined as **not giving up.**
+
+---
+
+## Know where you are on the timeline
+
+Knowing where you are on the timeline helps you interpret what's happening.
+
+| Phase | What happens | What to do |
+|---|---|---|
+| First 72 hours | Strong cravings, insomnia, irritability | Physical cutoffs, HALT check |
+| Week 1 | Cravings peak | Craving surfing, talk to someone |
+| Month 1 | Fewer cravings, but flat mood | Lower expectations, keep doing other things |
+| Month 3 | Brain changes start | Notice small shifts |
+| Month 6 | "I've stopped" feeling | Don't drop your guard |
+| Year 1 | Life as a whole shifts | Accept the new you |
+| Year 2+ | Stability | "Not gambling" becomes normal |
+
+If you know "I'm in week two, flat mood is expected," you don't panic.
+If you know "I'm in month three, a strong craving can show up," you're ready to handle it.
+
+Knowing the timeline is knowing where you are.
+And knowing where you are tells you where you're heading.
+
+
+## References
+
+- Doidge, N. (2007). *The Brain That Changes Itself: Stories of Personal Triumph from the Frontiers of Brain Science*. Viking.
+- Volkow, N.D., Koob, G.F., & McLellan, A.T. (2016). Neurobiologic Advances from the Brain Disease Model of Addiction. *New England Journal of Medicine*, 374(4), 363-371.
+- Goldstein, R.Z., & Volkow, N.D. (2011). Dysfunction of the prefrontal cortex in addiction: neuroimaging findings and clinical implications. *Nature Reviews Neuroscience*, 12(11), 652-669.
+- Koob, G.F., & Volkow, N.D. (2016). Neurobiology of addiction: a neurocircuitry analysis. *The Lancet Psychiatry*, 3(8), 760-773.
+- Joutsa, J., Johansson, J., Niemelä, S., Ollikainen, A., Hirvonen, M.M., Piepponen, P., et al. (2011). Mesolimbic dopamine release is linked to symptom severity in pathological gambling. *NeuroImage*, 60(4), 1992-1999.
+- Patzelt, E.H., Kurth-Nelson, Z., Lim, K.O., & MacDonald III, A.W. (2014). Excessive state switching underlies reversal learning deficits in cocaine users. *Drug and Alcohol Dependence*, 134, 211-217.
+- Berridge, K.C., & Robinson, T.E. (2016). Liking, wanting, and the incentive-sensitization theory of addiction. *American Psychologist*, 71(8), 670-679.
+- Bartzokis, G., Beckson, M., Lu, P.H., Edwards, N., Bridge, P., & Mintz, J. (2000). Brain maturation may be arrested in chronic cocaine addicts. *Biological Psychiatry*, 48(7), 605-611.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/cognitive-distortions.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/cognitive-distortions.md
@@ -1,0 +1,224 @@
+---
+category: "gambling"
+part: "C"
+chapter: 12
+title: "Cognitive Distortions: Three Illusions the Gambling Brain Creates"
+required: false
+excerpt: "6 p.m. Inside the casino. Four hours in. $300 gone."
+updatedAt: "2026-04-22"
+---
+6 p.m.
+Inside the casino.
+Four hours in.
+$300 gone.
+
+"I've been on this machine this long, a hit has to be coming"
+"If I quit now, I lock in a $300 loss. One more round and I'll get it back"
+"This machine's been tight all day. It's due"
+
+Three thoughts, running at the same time.
+From the outside, they all look wrong.
+Sitting at the machine, they all feel like facts.
+
+---
+
+## What cognitive distortions are
+
+A cognitive distortion is a pattern of thought that drifts away from reality.
+It's not unique to addiction. Everyone has them. But in the gambling brain, specific patterns get especially loud.
+
+Why do they get loud in a gambling brain? Two reasons.
+
+1. **The dopamine trap**: dopamine is overreleased. The brain wants a reason to act
+2. **Loss aversion**: people hate locking in a loss. When a loss is about to be final, the distortions whisper "you can still win it back"
+
+So cognitive distortions are "reasons to go" and "reasons not to stop," manufactured after the fact by your brain.
+And they don't feel manufactured from the inside. They feel like sound judgment.
+
+This chapter covers three distortions that hit gambling addiction especially hard:
+the gambler's fallacy, the sunk cost effect, and the illusion of control.
+
+---
+
+## The gambler's fallacy: "the next one is coming"
+
+### What it looks like
+
+- "I've been losing a while, I'm due"
+- "Three near-misses in a row. The next one hits"
+- "Five blacks in a row. Red has to be next"
+- "Been losing for a month. The streak is turning"
+
+All of these are the gambler's fallacy.
+The belief that past results affect future probability.
+
+### The reality
+
+In most gambling, outcomes are what statisticians call "independent trials."
+The result of this trial has nothing to do with previous trials.
+
+Example: a slot machine with a 1-in-319 chance of hitting.
+If the machine has missed 500 spins in a row, the 501st spin is still 1-in-319.
+The 501st isn't more likely to hit than the first.
+
+"I've been losing so I'm due" is, at the level of probability, false.
+
+(While we're here: 1-in-319 doesn't mean "you'll hit if you spin 319 times." Spin 319 times and your chance of having hit at least once is about 63%. Roughly 37% of people spinning 319 times will never hit.)
+
+### Why the brain feels it
+
+The human brain is bad at processing randomness.
+When the same result happens in a row, your brain expects the opposite next.
+This is a side effect of our pattern-recognition ability, which evolved to be useful elsewhere.
+
+It's useful most places. On a gambling floor, it backfires.
+
+### How to break it
+
+Carry the fact: "the next trial's probability is the same, no matter the streak."
+Pull it up when you're in front of the machine.
+
+Say it out loud if you have to.
+"This is the gambler's fallacy. The probability doesn't change."
+Even saying it in your head weakens the distortion a little.
+
+---
+
+## Sunk cost: "if I quit now, it's all wasted"
+
+### What it looks like
+
+- "I've lost $300. If I quit I eat the whole loss. One more round to win it back"
+- "I've been on this machine for hours, can't give it up now"
+- "I've come this far, I have to keep going"
+- "I've been here 8 hours. After 8 hours, what's another 2"
+
+This is the sunk cost effect.
+Trying to recover money already spent by spending more.
+
+### The reality
+
+The reality is simpler than the feeling.
+**The $300 you already spent isn't coming back whether you stop or continue.**
+
+Money you've already spent is called a sunk cost.
+It's gone. It has no bearing on future decisions.
+The only thing to decide is "what happens if I keep going from here."
+
+If you put in another $100, what does probability say will happen?
+Almost always, that $100 is gone too.
+And you become harder to stop.
+
+### Why the brain feels it
+
+People hate locking in a loss.
+Admitting "that $300 is gone" carries a strong psychological pain.
+To avoid that pain, the brain writes a story: "it's not over yet, you can still get it back."
+
+You believe the story, and you put more money in.
+The loss grows instead of reversing.
+
+### How to break it
+
+"The money I already spent doesn't come back, whether I stop or continue."
+Write this in a notebook or your phone notes.
+
+Then tell yourself: "the only thing to decide now is what happens from here."
+This is a general principle, not just for addiction.
+It matters in work and in relationships, too. A lot of people get trapped in "I've come this far" and can't turn around.
+
+---
+
+## Illusion of control: "there's always a good bet somewhere"
+
+### What it looks like
+
+- "There's a hot machine somewhere today, I just have to find it"
+- "That slot by the corner hits on weekends"
+- "I've got an eye for the flow"
+- "I can read the data and pick the right bet"
+
+This is the illusion of control.
+Believing you can predict something that's actually unpredictable.
+
+### The reality
+
+The reality is harsh.
+**The odds on casino machines are fixed in advance by the manufacturer and regulated by gaming authorities.** Whether any individual machine is "about to hit" isn't something a player can know.
+Hours of studying a screen don't reveal "the next winner."
+
+The people most convinced they "have an eye" are, as a rule, the ones losing the most.
+Behavioral economics has shown this directly.
+Losing continuously doesn't dissolve the feeling of "I can see it."
+
+### Why the brain feels it
+
+People overestimate their own judgment.
+Past accidental wins reinforce the sense of "I have an edge."
+The brain remembers the hits and forgets the misses.
+
+That feeling then drives the next bet.
+
+### How to break it
+
+Write out, honestly, your last month's or last year's wins and losses.
+"On this date, won X; on that date, lost Y." All of them.
+
+Almost everyone ends up deeply negative.
+The "I have an edge" feeling conflicts with the numbers on the page.
+The conflict weakens the feeling.
+
+---
+
+## Three distortions at once
+
+The three don't run independently. They run together in the same moment.
+
+Look back at the opening scene:
+
+- "I've been on this machine this long, a hit has to be coming" → gambler's fallacy
+- "If I quit now, I lock in a $300 loss" → sunk cost
+- "This machine's been tight all day, it's due" → illusion of control + gambler's fallacy
+
+All three are firing simultaneously in your head.
+One by itself is easy to catch. Three at once produce a strong sense that "my judgment is right."
+
+Knowing the three gives you more chances to catch "hey, all three distortions are running right now."
+When you catch it, there's a moment of space to choose differently.
+
+---
+
+## How to notice them
+
+### Watch your own lines
+
+"The next one is coming." "Can't walk away now." "I know what I'm doing."
+When these start running in your head, that's the sign.
+
+On a calm day, write down five "distortion lines" you tend to say.
+When one of them shows up at the machine, you can flag it: "oh, that's the distortion."
+
+### Put them on paper
+
+In your head, a distortion feels true.
+On paper, it objectifies.
+
+Write "I've been losing so it's due." Then write next to it: "is this a fact?"
+It becomes easier to see that it isn't.
+
+### Borrow an outside view
+
+"If a friend were in this exact situation, saying this exact thing, what would I tell them?"
+With a friend, you'd say it calmly. "That doesn't add up."
+Point that same calm view at yourself.
+
+
+## References
+
+- Ladouceur, R., & Walker, M. (1996). A cognitive perspective on gambling. In P.M. Salkovskis (Ed.), *Trends in Cognitive and Behavioural Therapies* (pp. 89-120). Wiley.
+- Tversky, A., & Kahneman, D. (1971). Belief in the law of small numbers. *Psychological Bulletin*, 76(2), 105-110.
+- Kahneman, D. (2011). *Thinking, Fast and Slow*. Farrar, Straus and Giroux.
+- Arkes, H.R., & Blumer, C. (1985). The psychology of sunk cost. *Organizational Behavior and Human Decision Processes*, 35(1), 124-140.
+- Thaler, R.H. (1999). Mental accounting matters. *Journal of Behavioral Decision Making*, 12(3), 183-206.
+- Toplak, M.E., Liu, E., MacPherson, R., Toneatto, T., & Stanovich, K.E. (2007). The reasoning skills and thinking dispositions of problem gamblers: A dual-process taxonomy. *Journal of Behavioral Decision Making*, 20(2), 103-124.
+- Goodie, A.S. (2005). The role of perceived control and overconfidence in pathological gambling. *Journal of Gambling Studies*, 21(4), 481-502.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/craving-basics.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/craving-basics.md
@@ -1,0 +1,174 @@
+---
+category: "gambling"
+part: "B"
+chapter: 9
+title: "What a Craving Is, and How to Ride It Out"
+required: false
+excerpt: "Saturday, 10 a.m. A notification lights up my phone: 'NFL kickoff in 15 min.' It was an app I'd forgotten to delete. My thumb tapped it without thinking."
+updatedAt: "2026-04-22"
+---
+Saturday, 10 a.m. A notification lights up my phone.
+"NFL kickoff in 15 min."
+It was an app I'd forgotten to delete.
+My thumb tapped it without thinking.
+The screen opened. My pulse picked up.
+"I'm just looking, I won't bet," I told myself, already scrolling to the lines.
+Before I knew it, I'd placed a $30 three-leg parlay on the first game.
+I'd decided to quit three days earlier.
+
+---
+
+## What a craving is
+
+A craving is what happens when a cue sets off a sudden dopamine release.
+In the addicted brain, this response overshoots easily, triggered by small signals.
+
+The body gives consistent signs.
+
+- Heat in the back of your neck or chest
+- Pulse climbs
+- Mouth goes dry
+- Palms sweat
+- Breathing gets shallow
+- Tunnel vision
+
+At the same time, "justification" starts running in your head.
+
+- "Just today"
+- "Just once is fine"
+- "I'm just trying to get my stake back"
+- "Tonight's the night, I can feel it"
+
+These are all conditioned reflexes built into your brain over years of use. You can't stop them from firing.
+
+---
+
+## Cravings end
+
+The single most important thing about cravings: **they always end.**
+
+A craving moves like a wave:
+
+1. Something triggers it
+2. It intensifies
+3. It peaks
+4. It weakens
+5. It passes
+
+Peak typically hits in a few minutes to 15 minutes. Full passage is usually 20 to 30 minutes. This is consistent across studies.
+
+If you do nothing, the wave still passes.
+The problem is: most people can't "do nothing." Somewhere mid-wave, they decide "I can't take this" and act.
+
+So the skill you need isn't "fighting the wave." It's "watching the wave."
+
+---
+
+## Watching: craving surfing
+
+Craving surfing was developed in the U.S. in the 1980s and is now used across mindfulness-based relapse prevention programs.
+
+It's simple.
+
+1. **Acknowledge it arrived.**
+   Notice the craving. Say "there it is" in your head.
+   Don't suppress it. Don't try to push it away.
+
+2. **Observe what's happening in your body.**
+   Heat in the neck. Fast heart. Sweaty palms.
+   Label each one.
+
+3. **Watch it like a wave.**
+   "It's getting stronger." "Peak is close." "Peak." "Weakening." "It's passing."
+   Take the observer position. Don't become the wave.
+
+4. **Check the clock.**
+   Peak in 5 to 10 minutes. Full passage in 20 to 30.
+   Watching the clock gives you a felt sense that this thing ends.
+
+It's hard at first. You'll try to watch and get pulled under. With practice, the part of you that watches grows.
+
+"Don't fight, observe." That's the core of craving surfing.
+
+---
+
+## Back to the senses: 5-4-3-2-1 grounding
+
+When the craving is too strong to observe, there's another basic skill.
+5-4-3-2-1 grounding, used for anxiety attacks and strong cravings.
+
+How to do it:
+
+1. **Five things you can see**, said out loud or in your head. "Wall, poster, vending machine, someone's shoes, my shadow."
+2. **Four sounds you can hear.** "Cars outside, voices, an announcement, my breathing."
+3. **Three things you're touching.** "My shirt against my skin, my feet in my shoes, the phone in my hand."
+4. **Two smells.** "Coffee, the laundry detergent on my sleeve."
+5. **One taste.** "The leftover coffee in my mouth."
+
+When it's done, run through it again.
+You're forcibly switching your brain's attention away from "the past experience (gambling)" and "the future fantasy (winning back)" toward "the senses happening now."
+
+The same technique is used for anxiety and trauma care.
+
+---
+
+## Physical handling: minimal skills for a crisis
+
+When you can't observe, can't ground, the simplest methods:
+
+### Physically leave
+
+The single most effective move.
+Walking past a casino? Turn and walk the other way.
+About to open the sports betting site on your laptop? Put the laptop in another room and walk outside.
+
+When the cue goes away, the wave weakens.
+The brain's physical response gets broken by a physical action. That's the fastest way out.
+
+### Call someone
+
+Talking out loud flips your brain's state.
+Topic doesn't matter. You can say "I'm in a craving." You can talk about anything else.
+The point is shifting from "alone" to "in a conversation."
+
+Decide who you'll call in advance. Trying to pick in the middle of a craving is hard.
+
+### Use a strong physical sensation
+
+A strong sensation redirects attention.
+Cold water on your face. Ice in your hand. Strong mint gum. A strong scent.
+These are temporary, but they get you past the peak.
+
+---
+
+## Things not to do
+
+Some attempts backfire.
+
+### Trying to suppress
+
+The more you tell yourself "don't think about it," the stronger the thought gets. This is the "white bear effect." Tell someone not to think about a white bear, and they can't stop.
+Trying to make a craving "not exist" makes it rebound harder.
+You have to observe, not suppress.
+
+### Trying to hold out alone forever
+
+"I'll tough it out myself" is a recipe for burnout.
+Cravings come many times. Holding out once isn't the problem.
+Combine: lean on people, physically leave, let time pass.
+Keep picking "endure alone" and eventually you break all at once.
+
+### Praying for cravings to stop
+
+The more you've stopped, the more they come. It takes time before they really fade.
+"Please don't come" is less useful than "be ready when they come."
+
+
+## References
+
+- Marlatt, G.A., & Gordon, J.R. (Eds.) (1985). *Relapse Prevention: Maintenance Strategies in the Treatment of Addictive Behaviors*. Guilford Press.
+- Bowen, S., Chawla, N., & Marlatt, G.A. (2010). *Mindfulness-Based Relapse Prevention for Addictive Behaviors: A Clinician's Guide*. Guilford Press.
+- Witkiewitz, K., Marlatt, G.A., & Walker, D. (2005). Mindfulness-based relapse prevention for alcohol and substance use disorders. *Journal of Cognitive Psychotherapy*, 19(3), 211-228.
+- Tiffany, S.T., & Wray, J.M. (2012). The clinical significance of drug craving. *Annals of the New York Academy of Sciences*, 1248(1), 1-17.
+- Wegner, D.M. (1989). *White Bears and Other Unwanted Thoughts*. Viking Press.
+- Najavits, L.M. (2002). *Seeking Safety: A Treatment Manual for PTSD and Substance Abuse*. Guilford Press.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/debt-overview.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/debt-overview.md
@@ -1,0 +1,280 @@
+---
+category: "gambling"
+part: "D"
+chapter: 17
+title: "The Full Picture of Your Debt: Facing the Numbers"
+required: false
+excerpt: "Saturday morning, at the kitchen table. Pen, notebook, and a stack of unopened envelopes. Five collection notices, still sealed."
+updatedAt: "2026-04-22"
+---
+<div class="note">
+
+This chapter is general information. For specific debt questions, work with a non-profit credit counselor (NFCC-member agencies), a free legal aid clinic, or a consumer-protection attorney.
+
+</div>
+
+Saturday morning, at the kitchen table.
+Pen, notebook, and a stack of unopened envelopes.
+Five collection notices, still sealed.
+
+Opening the first one took twenty minutes.
+Reading it took another ten.
+When I saw the amount, the room went gray.
+
+"So this is what I actually owe," I thought.
+It was three times what I'd been telling myself it was in my head.
+
+Still, I wrote it down.
+I opened every bill, wrote every number.
+Getting the total took three hours.
+When I saw the total, I couldn't move for a while.
+
+That night, though, I slept better than I had in three years.
+"Not knowing" had been harder than "knowing."
+
+---
+
+## Why people don't know their total debt
+
+Most people with gambling addiction don't actually know what they owe.
+"Roughly this much," they say. They don't have the real number.
+And "roughly" is almost always an underestimate.
+
+Four reasons.
+
+### It's scary to know
+
+The biggest one.
+Seeing the real number makes it real.
+While it's "roughly" in your head, you can keep some distance from the reality.
+To avoid the fear, you don't look.
+
+### You don't know how to check
+
+Debt spread across multiple creditors means checking each one separately.
+One's on a banking app. One's on a statement. One's on a login. One's a letter that arrives in the mail.
+Every issuer has its own channel. It's tedious.
+
+### The mail stays unopened
+
+"If I open the envelope, it becomes real." Many people keep their collection letters sealed.
+Stuff them in a drawer. Throw them out. Burn them.
+These are "don't look" behaviors. They don't make the debt disappear.
+
+### "I'll figure it out later" is running
+
+One of the denials from [Chapter 16](/en/learn/quit-gambling-today/denial/).
+"When I get a raise." "When I win some back." "Someday."
+This "someday" keeps supplying the reason not to look.
+
+---
+
+## The emotional process of facing your debt
+
+Facing the numbers is genuinely hard.
+It's not "write and done." Waves of feeling come through.
+
+### Seeing the number: shock
+
+The first time you see the real total, the room goes gray.
+"This is me."
+Your breath goes short. You can't move.
+
+That's a normal reaction.
+Most people feel it.
+
+### Hours to days later: confusion, despair
+
+After shock comes confusion and despair.
+"I'm done." "I may as well die." "I can't tell my family."
+These thoughts loop.
+You may lose sleep or appetite for a stretch.
+
+This is one of the highest-risk windows. Have your [safety plan](/en/learn/quit-gambling-today/safety-plan/) ready.
+Pick one person you can call.
+
+### Days to weeks later: moving to action
+
+As the wave of despair drops a little, "I have to do something" starts.
+That's the doorway into action.
+
+Don't let "I have to do something" stay vague. Turn it into specific, small moves.
+- Call a free legal aid clinic
+- Tell your family
+- Organize statements
+- Contact one creditor
+
+One small action enables the next. A chain starts.
+
+### Weeks to months later: organizing and rebuilding
+
+As actions chain, the view of your situation changes.
+The numbers are the same, but "what I need to do" becomes visible.
+"It's over" turns into "I'm making progress."
+
+Resolving debt takes time. But knowing you're moving changes how you feel inside the process.
+
+---
+
+## Getting your real total, step by step
+
+### What you need
+
+- Pen, notebook, or a spreadsheet
+- Past bank and credit card statements, mail
+- Your phone (for logging into creditor portals)
+- A quiet place, 3 to 4 hours
+- Safety set-up (one person you can reach if this gets hard)
+
+### Step 1: List every creditor
+
+Write down every place you owe money. Don't miss any.
+
+Main categories:
+- Credit cards (multiple)
+- Store cards and retail financing (Best Buy, Home Depot, etc.)
+- Buy-now-pay-later (Klarna, Affirm, Afterpay)
+- Personal loans
+- Payday loans and title loans (cash-advance loans)
+- Lines of credit at banks
+- Revolving balances with interest
+- Medical debt
+- Auto loans
+- Money borrowed from family or friends
+- Pawn shop items pledged
+- Advances against future paychecks
+- Loan sharks, if any. Include them. This is a police matter, not something to handle alone
+
+### Step 2: Get the actual balance from each one
+
+For each item on the list, pull the exact current balance.
+Channel varies:
+
+- Credit cards: app or website
+- Personal loans: lender's portal
+- Payday loans: lender's app or call
+- Store cards: statements
+- BNPL: app
+- Family/friends: ask directly, or look back through messages
+
+If you can't find it, call the creditor.
+"I'd like to confirm my current balance." After ID verification, they'll tell you.
+
+### Step 3: Put it in a table
+
+Pull everything into one table.
+
+| Creditor | Type | Balance | Monthly payment | APR |
+|---|---|---|---|---|
+| Issuer A | Credit card | $X,XXX | $XXX | XX.X% |
+| Lender B | Personal loan | $X,XXX | $XXX | XX.X% |
+| ... | | | | |
+| **Total** | | **$XX,XXX** | **$X,XXX** | |
+
+Sum it up.
+This is your actual debt.
+
+### Step 4: Total your monthly payments
+
+Alongside the total debt, your total minimum monthly payment matters a lot.
+Compare it to your take-home pay.
+
+- Monthly payments at 30%+ of take-home: already difficult
+- At 50%+: basically unsustainable
+- At 70%+: daily life collapses
+
+This number feeds into the legal options in the next chapter.
+
+---
+
+## What to do after the number is on paper
+
+### Tell one trusted person
+
+Once the number exists, tell exactly one person you trust.
+Family, friend, clinician, counselor, GA sponsor, anyone.
+Saying it breaks the isolation.
+If what you wrote stays hidden from everyone, it becomes easy to "un-know" again.
+
+"I actually owe $___" is enough. One sentence.
+You don't have to control their reaction.
+
+### Call a non-profit credit counselor (NFCC-member agency)
+
+In the U.S., the National Foundation for Credit Counseling (NFCC) certifies non-profit credit counseling agencies.
+They offer free or low-cost consultations, build a realistic budget with you, and explain your options.
+
+Tell them you want to talk about debt. They'll walk you through state-specific options and refer you as needed.
+You can ask for the consultation without committing to anything.
+
+### Free legal aid
+
+Legal aid clinics exist in most metropolitan areas for people who qualify by income.
+State bar associations also run lawyer-referral services, and some offer reduced-fee initial consultations.
+
+Mention that gambling is part of the picture. A decent attorney will treat the whole situation, not just the debt in isolation.
+
+### Talk to a consumer-protection attorney or bankruptcy attorney
+
+For legal options, a consumer bankruptcy attorney is the right specialist.
+Many offer a free initial consultation. If cost is a concern, ask about fee structure upfront.
+
+Details on debt settlement, Chapter 13, and Chapter 7 bankruptcy are in the next chapter ([Chapter 18](/en/learn/quit-gambling-today/legal-options/)).
+
+### Stop the next round of new debt
+
+The moment you have the total, lock down your ability to add more.
+- Do every step in [Chapter 6 (cutting off access to money)](/en/learn/quit-gambling-today/money-access/)
+- Hand cards, checkbooks, IDs to a trusted person
+- Freeze your credit at Equifax, Experian, TransUnion
+
+Doing the legal debt process without the prevention step puts you right back here.
+Resolve past debt and block future debt. Both, at the same time.
+
+---
+
+## "Knowing the number" is the start, not the end
+
+Knowing your debt is stepping onto the starting line. It's not the finish line.
+
+Even after the number is known:
+
+- Craving waves still come
+- Family trust doesn't rebuild overnight
+- Work and life pressure continue
+- Legal resolution takes time
+- Your credit report shows the impact for years
+
+These are real.
+But being in this state is much better than the "don't know" state. You can move forward.
+
+Resolving debt takes months or years.
+Throughout that time, the recovery process continues.
+The rest of this book covers what you need for "recovering while resolving."
+
+---
+
+## When you can't get yourself to look at the numbers
+
+Reading this chapter doesn't mean you'll write the numbers tonight. Finishing the chapter and still feeling "I get it, but I still can't" is typical.
+
+In that case, start smaller.
+
+- Open one unopened envelope
+- Open one creditor's website to the login page
+- Pull out one statement
+- Write just the creditor names (no balances yet)
+- Save a free legal aid number in your phone
+
+These are the steps before "knowing your debt."
+Perfect doesn't matter. One millimeter forward today links to one millimeter tomorrow.
+
+
+## References
+
+- National Foundation for Credit Counseling. https://www.nfcc.org/
+- Consumer Financial Protection Bureau. *Dealing with debt*. https://www.consumerfinance.gov/
+- American Bar Association. *Free and low-cost legal help*.
+- National Council on Problem Gambling. *Financial help for gambling*. https://www.ncpgambling.org/
+- Cox, B.J., Yu, N., Afifi, T.O., & Ladouceur, R. (2005). A national survey of gambling problems in Canada. *Canadian Journal of Psychiatry*, 50(4), 213-217.
+- Sacco, P., Cunningham-Williams, R.M., Ostmann, E., & Spitznagel, E.L. (2008). The association between gambling pathology and personality disorders. *Journal of Psychiatric Research*, 42(13), 1122-1130.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/denial.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/denial.md
@@ -1,0 +1,222 @@
+---
+category: "gambling"
+part: "D"
+chapter: 16
+title: "Denial: The Wall of 'I'm Fine'"
+required: false
+excerpt: "'I'm not an addict.' 'I could stop if I really wanted to.' 'I just haven't stopped yet.' 'I'm not like those other guys.' 'He was bad enough to need treatment. I'm not there yet.'"
+updatedAt: "2026-04-22"
+---
+"I'm not an addict."
+"I could stop if I really wanted to."
+"I just haven't stopped yet."
+"I'm not like those other guys."
+"He was bad enough to need treatment. I'm not there yet."
+
+One person said these, out loud, for five years.
+In those five years, the debt passed $50,000.
+His family discovered the hidden debt, and only then did he admit he couldn't stop.
+
+For those five years, saying "I could stop if I wanted," he didn't think he was lying.
+He believed it.
+That's denial.
+
+---
+
+## What denial is
+
+Denial is the mind's way of treating a fact as "not a fact."
+It's not a conscious lie. The person truly feels what they're saying.
+
+In addiction medicine, denial is treated as a symptom of the disease.
+It shows up in gambling disorder, alcohol use disorder, substance use disorders, all of them.
+
+Denial's job is to protect the person from pain.
+Admitting "I have an addiction" hurts.
+To soften the hurt, the brain filters the world through "I'm fine."
+
+The filter is invisible from the inside.
+You're looking through it, so you can't see it.
+That's what makes denial hard to spot.
+
+---
+
+## Common denial patterns
+
+### "I could stop if I wanted to"
+
+The most common one.
+The person really believes it.
+Except they haven't actually stopped.
+
+Reality: if you've tried to stop many times and haven't, that's the definition of "I can't stop."
+
+### "I'm not in financial trouble"
+
+There's debt. But it feels "not bad enough."
+"I can handle this on my income."
+"Other people have worse debt than me."
+
+Reality: put the debt amount and a repayment plan on paper.
+Have a third party look at whether this is actually "not bad."
+
+### "If I stop gambling, I'll just get unhealthy in other ways"
+
+"I'll have no way to manage stress."
+"I'll replace it with another addiction."
+"People need a release valve."
+These arguments run in your head.
+
+Reality: gambling doesn't relieve stress. You're just not noticing it for a while, and stress is larger when you walk out than when you walked in.
+If you experience gambling as "stress relief," you already have the structure of addiction.
+
+### "I'm different from those people"
+
+"Those are real addicts. I'm different."
+"I'm still doing my job. My family life is okay."
+"I still have control."
+
+Reality: if you had control, you wouldn't be reading this book.
+
+### "My family isn't affected"
+
+"I haven't told them, so they don't know."
+"It's not affecting them."
+"I'm using my own money, so it's my issue."
+
+Reality: your family usually notices. They notice and stay quiet.
+The act of hiding, by itself, is affecting your family.
+
+### "I'll stop eventually"
+
+"Can't do it now, but someday I will."
+"When the kids are older." "When work calms down." "When money is easier."
+"Someday" never arrives.
+
+Reality: pushing "someday" into the future, forever, is itself a hallmark of addiction.
+
+### "I actually enjoy gambling"
+
+"It's not something to stop, it's a hobby."
+"Other people spend money on hobbies too."
+"It's like golf, or travel."
+
+Reality: hobbies leave you feeling good afterward.
+If you don't feel better after gambling, it isn't a hobby.
+As we saw in [Chapter 2 (the dopamine trap)](/en/learn/quit-gambling-today/dopamine-trap/), the addicted brain stops registering enjoyment.
+
+---
+
+## How to notice denial
+
+### "What would I think if someone else said this?"
+
+Run your own thoughts through an outside view.
+"If someone told me 'I could stop if I wanted,' and they'd tried and failed ten times, what would I think?"
+
+Almost everyone can calmly answer: "that's a person who can't stop."
+Point that calm view at yourself.
+
+### Use numbers
+
+Denial runs on feelings. Facts run on numbers.
+- How much did you spend on gambling last month?
+- How much in the last year?
+- What's the total debt?
+- How many times have you "decided to stop"?
+- What's the longest stretch you've actually stopped for?
+
+Put these on paper.
+The gap between the numbers and how you feel shows up clearly.
+
+### Ask family or friends, honestly
+
+Ask someone you trust: "Do you think I have a gambling addiction?"
+Usually, they've thought so for a while.
+Often, you're the last person to see it.
+
+### Try a quick self-screen
+
+There are several addiction self-checks. A simple one is the "Lie/Bet" questionnaire, two questions:
+
+- Have you ever lied to people important to you about how much you gamble?
+- Have you ever felt the need to bet more and more money?
+
+Two yeses suggest a high likelihood of gambling disorder.
+This isn't a diagnosis, but it's a wedge into the wall of denial.
+
+---
+
+## How to start breaking through denial
+
+### Admit "I might be in denial"
+
+This sounds contradictory.
+If you're in denial, how can you admit to being in denial?
+
+You actually can.
+Say, in your head: "I might be in denial right now."
+That alone makes the filter partially transparent for a moment.
+
+You don't have to fully break out of denial.
+Just holding "I might be in denial" shifts how you behave.
+
+### Write your state down
+
+Don't think. Write.
+Writing makes the filter visible to you.
+
+Things to write:
+- Last month's spending
+- Total debt
+- Number of times you've "decided to stop"
+- How your family relationships have changed
+- How many times you've lied to yourself
+
+Read what you wrote the next morning.
+It often reads differently in the morning than it did at night.
+
+### Get away from voices that reinforce denial
+
+Distance yourself from people and content that strengthens denial.
+- The friend who says "you're not that bad"
+- The "everyone does it" crew
+- Social media or YouTube channels that treat gambling casually
+
+The longer you stay plugged in, the more reinforced the filter gets.
+
+### Spend time where denial gets weaker
+
+Actively seek spaces where denial loses ground.
+- GA or other support groups (hearing people who've been through the same thing)
+- Memoirs and accounts from people in recovery
+- Reading timelines in the [QuitMate](https://about.quitmate.app/) community
+- Time with trustworthy family
+- Medical providers and counseling centers
+
+Seeing "people with the same symptoms as me" thins the filter.
+"I'm different" turns into "I'm the same" in specific moments.
+
+---
+
+## Denial comes back
+
+Denial isn't "broken through once, then done."
+It keeps coming back.
+
+Even well into recovery, denial can return.
+"I'm cured now." "Just one more time would be fine." "I can be a normal person again."
+These are late-stage denials.
+
+Whether you can recognize returning denial as a symptom, or fall for it, is often the difference between staying in recovery and relapsing.
+
+
+## References
+
+- Johnson, V.E. (1986). *Intervention: How to Help Someone Who Doesn't Want Help*. Hazelden.
+- Carnes, P. (2001). *Out of the Shadows: Understanding Sexual Addiction* (3rd ed.). Hazelden.
+- Cunningham, J.A., Hodgins, D.C., & Toneatto, T. (2009). Relating severity of gambling to cognitive distortions in a representative sample of problem gamblers. *Journal of Gambling Issues*, 23, 147-153.
+- Johnson, E.E., Hamer, R., Nora, R.M., Tan, B., Eisenstein, N., & Engelhart, C. (1997). The Lie/Bet Questionnaire for screening pathological gamblers. *Psychological Reports*, 80(1), 83-88.
+- Lesieur, H.R., & Blume, S.B. (1987). The South Oaks Gambling Screen (SOGS): A new instrument for the identification of pathological gamblers. *American Journal of Psychiatry*, 144(9), 1184-1188.
+- Ferris, J., & Wynne, H. (2001). *The Canadian Problem Gambling Index: Final Report*. Canadian Centre on Substance Abuse.
+- Khantzian, E.J. (2003). The self-medication hypothesis revisited: The dually diagnosed patient. *Primary Psychiatry*, 10(9), 47-54.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/dopamine-trap.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/dopamine-trap.md
@@ -1,0 +1,115 @@
+---
+category: "gambling"
+part: "A"
+chapter: 2
+title: "The Dopamine Trap: Why You Can't Stop Even When It's Not Fun"
+required: false
+excerpt: "Day after payday. I stopped at the casino on the way home. Out of the $300 I had on me, $200 got swallowed by the machines. Walking back to the car, I was confused. If someone had asked whether I had fun, I couldn't have answered."
+updatedAt: "2026-04-22"
+---
+Day after payday. I stopped at the casino on the way home. Out of the $300 I had on me, $200 got swallowed by the machines.
+
+Walking back to the car, I couldn't make sense of it. Losing was nothing new, but this time, even the moment of a win didn't land. "Hit," my head said, but I felt nothing. I still moved to the next machine, and the next.
+
+It wasn't because it was fun. So why was I still there?
+
+I kept turning that over in my head all the way home.
+
+---
+
+## What dopamine actually is
+
+Dopamine is a chemical in your brain that's tied to reward. It gets called the "pleasure chemical," and that's half right, half wrong.
+
+What dopamine actually does is fire when your brain senses a reward is coming. It fires on the anticipation, and it pushes you to act on it.
+It's the mechanism that keeps you repeating behaviors your body needs to survive: eating, exercising, connecting with other people.
+
+Pleasure itself is made by a different system. A separate circuit in the brain (scientists call it the opioid system, among others) produces the "that felt good, I'm satisfied" sensation.
+
+"Dopamine = pleasure" is the myth.
+"Dopamine = wanting, craving" is closer to the truth.
+
+---
+
+## "Wanting" and "liking" are separate in the brain
+
+Recent research has shown that "wanting" and "liking" run on different circuits in the brain.
+
+- **Wanting**: the pressure that drives "more, more"
+- **Liking**: the sensation of "that felt good, I'm satisfied"
+
+Normally these two move together.
+You want to eat something good (wanting), you eat it, it tastes good (liking), you feel satisfied.
+In normal life these are so tightly coupled that you don't need to separate them.
+
+But in gambling addiction, they split apart.
+
+---
+
+## You can't stop, even though it's not fun
+
+In an addicted brain, the "wanting" circuit fires strong, but the "liking" circuit has gone quiet. So you feel the pull to act, but when you act, the payoff is thin. It's not satisfying, so you do it again to try to get the satisfaction. It's still not satisfying. Again. Again.
+
+"Can't stop even though it's not fun" is not a character issue or a willpower issue. It's the physical result of "wanting" and "liking" being disconnected in your brain.
+
+The scene at the start of this chapter, "'Hit,' my head said, but I felt nothing," is exactly what that disconnection feels like. Many people in recovery describe the same thing.
+
+---
+
+## The more you do it, the louder "wanting" gets
+
+Normally, when you get the same stimulus over and over, your brain dulls to it. That's tolerance.
+In gambling addiction, the opposite happens. The "wanting" response to cues grows stronger the longer you keep going.
+The medical term is "sensitization," which just means getting more sensitive.
+
+In practice:
+
+- The sound of slot machines, the jingle when you open a betting app, the push notification for kickoff
+- Your brain's response to these cues grows stronger month by month, year by year
+- The first time you walked past a casino, you felt nothing. A year later, your feet slow down. Five years later, seeing a casino sign from across the street is enough to raise your pulse
+
+"Wanting" keeps getting louder. "Liking" keeps getting quieter.
+The gap widens as the addiction deepens.
+
+---
+
+## "The feeling of your first big win" is not coming back
+
+Something most people in recovery have felt:
+
+"I just want to feel the way I did the first time I hit big."
+
+That feeling isn't coming back.
+Two reasons.
+
+1. The "liking" circuit in your brain has been dulled by repetition.
+2. Only "wanting" runs out in front now, and no matter how much you feed it, it doesn't get full.
+
+If you chase "how it felt back then" without knowing this, you'll burn through money and time. You eventually realize you're trapped in a loop of doing something you don't even enjoy.
+
+Chasing something that isn't coming back is exhausting.
+Admitting "it's not coming back" hurts, but it's also the doorway out of the trap.
+
+---
+
+## What helps you get out
+
+Understanding the dopamine trap isn't an instant cure. But it changes two things.
+
+First, you can stop beating yourself up. "Can't stop even though it's not fun" is not a personality defect. It's the physical result of "wanting" and "liking" being disconnected. A lot of people with gambling addiction have driven their self-worth into the ground because they blame themselves. Once you believe "my will is weak," you lose the energy you need to do the things that actually help. Knowing the mechanism breaks that cycle.
+
+Second, you can start moving toward other forms of "liking." The "liking" you lost to gambling, you need to rebuild somewhere else. Move your body. See people. Make something. Learn something. Sleep. Eat well. Get some sun.
+
+In the beginning, these things feel thin. Compared to the intensity of gambling, they barely register. But if you keep at them, the "liking" circuit in your brain slowly starts to come back. It takes time. Weeks. Months. For some people, a year or more.
+
+The highs from gambling are not coming back. But your ability to feel small everyday pleasures can.
+
+
+## References
+
+- Berridge, K.C., & Robinson, T.E. (2016). Liking, wanting, and the incentive-sensitization theory of addiction. *American Psychologist*, 71(8), 670-679.
+- Robinson, T.E., & Berridge, K.C. (1993). The neural basis of drug craving: an incentive-sensitization theory of addiction. *Brain Research Reviews*, 18(3), 247-291.
+- Robinson, T.E., & Berridge, K.C. (2008). The incentive sensitization theory of addiction: some current issues. *Philosophical Transactions of the Royal Society B*, 363(1507), 3137-3146.
+- Schultz, W. (1997). Dopamine neurons and their role in reward mechanisms. *Current Opinion in Neurobiology*, 7(2), 191-197.
+- Volkow, N.D., Koob, G.F., & McLellan, A.T. (2016). Neurobiologic Advances from the Brain Disease Model of Addiction. *New England Journal of Medicine*, 374(4), 363-371.
+- Koob, G.F., & Volkow, N.D. (2016). Neurobiology of addiction: a neurocircuitry analysis. *The Lancet Psychiatry*, 3(8), 760-773.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/family.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/family.md
@@ -1,0 +1,302 @@
+---
+category: "gambling"
+part: "D"
+chapter: 19
+title: "Family Relationships: From the Gambler's Side"
+required: false
+excerpt: "Saturday afternoon. The couch in the living room. My wife took the kids to her parents' house."
+updatedAt: "2026-04-22"
+---
+<div class="note">
+
+This chapter is from the perspective of the person with gambling addiction. Content specifically for family members (Gam-Anon, family groups, how to support a gambler) is covered separately.
+
+</div>
+
+Saturday afternoon.
+The couch in the living room.
+My wife took the kids to her parents' house.
+
+Three days ago, she found another hidden debt.
+This one: $15,000.
+She packed a bag and left, crying but silent.
+
+"I'll be at my parents' through next weekend. I need to think about what we're going to do."
+The note was on the kitchen table.
+
+Ten years together.
+How many times have I apologized in those ten years.
+How many times have I said "I'm done."
+How many times have I broken that promise.
+
+Every apology had been real when I said it.
+I believed myself each time.
+But the pattern made the words into lies.
+I didn't think anything I could say would reach her now.
+
+---
+
+## The impact on your family
+
+Gambling addiction isn't only about you.
+The people living with you carry a lot.
+
+### Financial impact
+
+- Tight household budget
+- Kids' education savings and household expenses cut
+- Family members covering your debt
+- Savings gone; sometimes homes lost
+
+### Psychological impact
+
+- Can't trust what you say
+- "Here we go again" becomes the baseline
+- Constant worry about money
+- Anger at being lied to
+- Resignation after being hurt many times
+- Self-blame ("is this somehow my fault")
+- Anxiety about extended family, work, neighbors finding out
+
+Your family is also worrying during the times you're not gambling.
+You might think "while I'm clean, I'm not hurting them." From their side, the worry "what if this starts again" never fully leaves.
+
+### Social impact
+
+- The family's social circle shrinks (shame keeps people in)
+- Kids can't talk about their parent
+- Tension with extended family
+- In some cases, having to move, change schools
+
+### Impact on their sense of self
+
+Your family has loved you.
+Living with addiction alongside that love, they've asked themselves "what am I living for" and "what did I do wrong."
+
+None of it is their fault.
+They've still carried those questions anyway.
+
+Family members need care of their own.
+There are family groups (Gam-Anon and similar) and family-focused counseling resources specifically for this.
+
+---
+
+## How trust breaks down
+
+Trust doesn't shatter in a single moment.
+Small lies and small broken promises stack up, and trust erodes over time.
+
+### It starts small
+
+At first, the lies are small.
+"I have to work late tonight" (actually at the casino).
+"My paycheck came through clean" (you skimmed off the top).
+"Grabbing drinks with coworkers" (again, gambling).
+
+The lies are small at first.
+Your family doesn't notice. Or notices and lets it slide.
+
+### The apology and betrayal cycle
+
+Debt or missing money surfaces.
+You cry. You apologize.
+"I'll never do it again."
+Your family believes you.
+
+Weeks or months later, it happens again.
+You cry. You apologize again.
+"This time for real."
+Your family believes you again (or receives it, half-resigned).
+
+This cycle repeats, many times.
+Each time, the "ability to believe" in your family shrinks a little more.
+
+### The moment "believing" hits zero
+
+At some point, your family's capacity to believe runs out.
+"I'm not listening anymore" arrives.
+It's not anger.
+They simply have no more energy for believing.
+
+The state of the wife in the opening scene is close to this.
+Not angry. Cold. Not believing anything.
+
+### After this, words don't bring them back
+
+Once belief has hit zero, however many times you say "I'll never do it again," nothing moves inside them.
+Words can't carry it anymore.
+From here on, only actions mean anything.
+
+---
+
+## How to talk to your family now
+
+### Don't confuse "apology" with "report"
+
+People who've apologized many times often don't realize that apologies have lost meaning.
+To your family, "I'm sorry" now triggers "here we go again."
+
+Switch from "apology" to "report."
+- "I've accepted that I have gambling addiction. I've started treatment"
+- "I have the full debt figured out: $XX,XXX"
+- "I've met with an attorney"
+- "Starting Monday, I'm going to GA meetings"
+
+Not apology for the past. Concrete actions going forward.
+What your family needs to hear isn't "I'm sorry." It's "what's going to be different."
+
+### Keep it short
+
+Don't go long.
+Long becomes indistinguishable from the excuses from before.
+
+Three things are enough.
+
+1. Your current state (fact)
+2. What you're going to do (action)
+3. What you need from them (request)
+
+Example:
+
+> "I owe $___.
+> I've accepted I have a gambling addiction. Treatment starts next week.
+> I need to hand over money management for the time being."
+
+Three lines. Any details they want, they can ask.
+
+### Don't require a reaction
+
+After you say it, don't require a specific reaction from them.
+Don't expect "forgiveness" or "understanding" on the spot.
+
+Your family often won't say anything in the moment.
+Anger, tears, silence, walking out, all of these are normal.
+Don't wait for a reaction. Keep doing the actions.
+
+### Don't over-promise
+
+"I'll never do it again."
+"This time for real."
+You've said these many times.
+Inside them, those phrases are already invalid.
+
+Instead, try:
+
+> "I can't promise 'never.'
+> What I can do is change the actions starting today.
+> And I'll show you what I'm doing every day."
+
+This isn't weakness.
+It's closer to reality.
+Addiction relapses. "Never" isn't something you can guarantee.
+What you can commit to is today's action.
+
+Saying "never" pushes trust further away.
+Showing today's action brings trust back, gradually.
+
+---
+
+## Rebuilding trust is a process
+
+Trust doesn't come back suddenly.
+It comes back over hundreds of days, years, piece by piece.
+Sometimes it doesn't fully come back.
+
+### How it comes back
+
+Trust returns through small, consistent things:
+
+- "30 days without gambling"
+- Staying on treatment appointments
+- Discussing finances without avoiding
+- Progress on debt
+- Stopping the hiding
+- More stable moods and reactions
+- Listening all the way through when your family talks
+
+These stack up over six months, a year, and slowly "maybe it's real this time" starts growing inside your family.
+A year is common. Two or three years isn't unusual.
+
+### Don't rush the process
+
+"I want them to forgive me already." "I want us back to how we were."
+That pressure will show up.
+The moment you push, your family's guard goes back up.
+It reads as "they're still thinking of themselves first."
+
+Go at their pace.
+Don't ask to be forgiven. Let them get there on their own schedule.
+
+### Some relationships don't come back
+
+Some relationships don't recover.
+- Divorce
+- Long-term distance from a child
+- Parent or sibling cutting you off
+
+These happen.
+Some readers of this book are already in that place.
+
+Your recovery continues regardless.
+"They didn't come back, so my life is over" isn't true.
+Family is part of your life. Recovery is about your life as a whole.
+
+---
+
+## When they're not ready to talk
+
+Sometimes your family isn't in a place to listen.
+- Too much anger
+- So much resignation they don't want to
+- Physically distant
+- Can only communicate through a third party
+
+Don't force it.
+Instead:
+
+- Keep acting (don't gamble, stay in treatment, keep resolving debt)
+- Communicate through a third party (therapist, doctor, attorney)
+- Send a short update by letter or message
+- Introduce your family to Gam-Anon or similar family support
+
+Long periods of no direct conversation are normal.
+Keep your recovery going through that time.
+Often, your family is watching from a distance even when you don't know it.
+
+---
+
+## If you have children
+
+Families with kids have one more piece.
+
+### Honesty with your kids
+
+Kids pick up on what's happening in the house, regardless of age.
+"The kids can't tell" is usually wrong. They can.
+
+At a level appropriate to their age, give them the honest version.
+"I'm being treated for something" is a simple version that works.
+Details can come later, when they're older and if it makes sense to share them.
+
+### Don't gamble, don't talk gambling, around your kids
+
+Any time or place with your kids: no gambling-related behavior, no gambling topics.
+This isn't just about protecting them.
+It's also about resetting your own state in their presence.
+
+### Make time with your kids
+
+Build in time with them on purpose during recovery.
+You don't have to be a perfect parent. Just being there more matters a lot to them.
+
+Kids learn from their parents' actions.
+Watching a parent face recovery is itself meaningful to a kid.
+
+
+## References
+
+- Hodgins, D.C., Toneatto, T., Makarchuk, K., Skinner, W., & Vincent, S. (2007). Minimal treatment approaches for concerned significant others of problem gamblers: A randomized controlled trial. *Journal of Gambling Studies*, 23(2), 215-230.
+- Kalischuk, R.G., Nowatzki, N., Cardwell, K., Klein, K., & Solowoniuk, J. (2006). Problem gambling and its impact on families: A literature review. *International Gambling Studies*, 6(1), 31-60.
+- Dowling, N., Smith, D., & Thomas, T. (2009). The family functioning of female pathological gamblers. *International Journal of Mental Health and Addiction*, 7(1), 29-44.
+- Gam-Anon International Service Office. https://www.gam-anon.org/
+- McCrady, B.S. (2004). To have but one true friend: Implications for practice of research on alcohol use disorders and social networks. *Psychology of Addictive Behaviors*, 18(2), 113-121.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/halt.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/halt.md
@@ -1,0 +1,168 @@
+---
+category: "gambling"
+part: "C"
+chapter: 11
+title: "HALT: Hungry, Angry, Lonely, Tired"
+required: false
+excerpt: "Friday, 9 p.m. Late at the office. Haven't eaten since noon. A client's mistake cost us, and my manager unloaded on me over it."
+updatedAt: "2026-04-22"
+---
+Friday, 9 p.m.
+Late at the office. Haven't eaten since noon.
+A client's mistake cost us, and my manager unloaded on me over it.
+My family is asleep by now.
+My socks are damp inside my shoes.
+
+The walk from the subway to my apartment.
+Passing a neon "SPORTSBOOK / SLOTS" sign, I stopped.
+Of course it was tonight that I'd notice it.
+
+The math starts in my head.
+"Still hours until close."
+"A quick session just to reset."
+"Nobody's up at home anyway."
+
+---
+
+## What HALT is
+
+HALT is an initialism for four words:
+
+- **H**ungry
+- **A**ngry
+- **L**onely
+- **T**ired
+
+It came out of Alcoholics Anonymous and now gets used across all kinds of addiction recovery.
+
+The idea is simple:
+"When any one of these is true, the trigger for addictive behavior gets pulled more easily."
+In reverse: "when a craving hits, first check whether one of these is happening."
+
+In the opening scene, all four were going at once.
+Relapses often involve two or more of these at the same time.
+
+---
+
+## What each one does to the brain
+
+### Hungry
+
+When your blood sugar drops, the brain's brakes weaken.
+Judgment drops. Impulses get harder to contain.
+
+This isn't specific to addiction. Anyone with low blood sugar makes sloppy decisions. Shopping and overspending, sending impulsive texts, snapping at people.
+An addicted brain is already starting with weakened brakes. Hunger compounds that.
+
+Nights that follow skipped meals are especially dangerous.
+
+### Angry
+
+Anger and frustration push you toward "I need a break" or "I need to let off steam." That feels like a reason to gamble.
+Stress-elevated cortisol pushes the brain to chase dopamine harder. It isn't stress relief. It's a stronger craving.
+
+The ride home after being yelled at. The minutes after a fight with a family member. The evening of a failure at work. These windows are especially risky.
+
+### Lonely
+
+Loneliness lights up a part of the brain close to the region that processes physical pain, according to imaging studies.
+We're social animals. Losing connection is processed as pain.
+
+To fill that pain, the brain reaches for addictive behavior.
+Inside a casino or inside a sportsbook, the noise and activity temporarily plug the hole of loneliness.
+Alone on the way home. An empty apartment. A weekend with nobody to talk to. These are triggers.
+
+### Tired
+
+When you're tired, the brain's decision-making fuel is depleted.
+You can't make new decisions. Only habitual behaviors come out.
+Addictive behavior is a long-practiced habit. A tired brain slides onto that track without deciding.
+
+Sleep deprivation is especially dangerous.
+Consecutive all-nighters. The morning after a night shift. Nights without sleep because of a new baby.
+Pass a casino in this state and your feet take you in on their own.
+
+If you can't sleep for stretches, start with sleep hygiene basics: no caffeine before bed, same sleep and wake times daily, dark and cool bedroom. If it's been three weeks or more of bad sleep, see a psychiatrist or sleep physician.
+
+---
+
+## Combinations get dangerous fast
+
+HALT's four pieces look independent, but they reinforce each other.
+
+- Tired means no energy to cook → skipped dinner, so hungry
+- Hungry means you're irritable at home → angry
+- Angry with no one to talk to → lonely
+- All of this stacked up makes you sleep poorly → more tired
+
+Multiple at once means the brain's brakes are essentially offline.
+
+In the Friday-night scene at the top of this chapter, all four were running.
+Three weeks of resolve was thin paper against that state.
+
+The judgment center was about as close to shut down as it gets.
+
+---
+
+## The basics of HALT-based prevention
+
+### When a craving hits, start with a HALT check
+
+Before you do anything, check the four in order.
+
+- Hungry: when did you last actually eat?
+- Angry: did something upset you today?
+- Lonely: when did you last really talk to someone?
+- Tired: how many hours did you sleep?
+
+If one of them is true, solve that first.
+
+### Filling the underlying need often makes the craving vanish
+
+When "I want to gamble" arrives, sometimes what's actually needed is something else.
+
+- Hungry → grab food at a convenience store
+- Angry → walk, talk to someone, write it out on paper
+- Lonely → text a friend, post in QuitMate
+- Tired → lie down, sleep
+
+Fill the actual need, and often the craving goes with it.
+What looked like "I want to gamble" was "I was hungry." Or angry. Or lonely. Or tired. That's the whole story, sometimes.
+
+### Prevention beats response
+
+HALT is stronger as prevention than as response.
+
+- Don't skip meals (lunch happens, no matter what)
+- Don't let stress pile up (discharge it the same day)
+- Reduce alone time on purpose (one human per day, at least once a week in person)
+- Protect sleep (6 hours minimum, 7 ideally)
+
+These are just human basics.
+For an addicted brain, they matter more than for anyone else.
+On days when the basics break down, the danger always rises.
+
+---
+
+## Know your own HALT pattern
+
+Not all four hit everyone equally.
+People tend to have a specific weak combination.
+
+- Hungry + Tired (day you worked through lunch and pulled overtime)
+- Lonely + Angry (alone commute after a manager argument)
+- Tired + Lonely (night after a late shift, going home to an empty place)
+
+Look back at past relapses. Your pattern shows up.
+Knowing the pattern lets you pre-flag the days where it's likely to line up.
+
+
+## References
+
+- Alcoholics Anonymous. *The Big Book*. Alcoholics Anonymous World Services. (Origin of the HALT concept)
+- Eisenberger, N.I., Lieberman, M.D., & Williams, K.D. (2003). Does rejection hurt? An fMRI study of social exclusion. *Science*, 302(5643), 290-292.
+- Cacioppo, J.T., & Hawkley, L.C. (2009). Perceived social isolation and cognition. *Trends in Cognitive Sciences*, 13(10), 447-454.
+- Vohs, K.D., Baumeister, R.F., Schmeichel, B.J., Twenge, J.M., Nelson, N.M., & Tice, D.M. (2008). Making choices impairs subsequent self-control: A limited-resource account of decision making, self-regulation, and active initiative. *Journal of Personality and Social Psychology*, 94(5), 883-898.
+- Sinha, R. (2008). Chronic stress, drug use, and vulnerability to addiction. *Annals of the New York Academy of Sciences*, 1141, 105-130.
+- Walker, M.P. (2017). *Why We Sleep: Unlocking the Power of Sleep and Dreams*. Scribner.
+- Kahneman, D. (2011). *Thinking, Fast and Slow*. Farrar, Straus and Giroux.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/if-then-plan.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/if-then-plan.md
@@ -1,0 +1,178 @@
+---
+category: "gambling"
+part: "C"
+chapter: 14
+title: "The Escape Plan: Acting Automatically in a Crisis"
+required: false
+excerpt: "9:30 a.m. I just dropped my son at daycare. I'm back home, and no one will be here until pickup."
+updatedAt: "2026-04-22"
+---
+9:30 a.m.
+Just dropped my son at daycare.
+Back home. Nobody else will be here until pickup.
+
+Put away the dishes, started a load of laundry, sat down on the couch.
+Hours of empty time until I need to leave.
+This empty stretch is always where it goes wrong.
+
+"Alone during the day is dangerous," I know it.
+Knowing it doesn't move my feet.
+Before I realized, I had my wallet in hand, standing at the door.
+
+---
+
+## "Decided" stops working in certain moments
+
+In calm moments, decisions feel solid.
+The you who said "not today" in the shower that morning. The you who said "I'm done with this life" at lunch.
+Those were real. You weren't lying.
+
+But after you drop off your kid, alone in the quiet house.
+The morning version of you isn't there anymore.
+What's there is a brain with weakened brakes and amplified "I want to."
+
+"I know" and "I can act on it" aren't the same thing.
+Knowing doesn't move your legs.
+We've covered this throughout the book: the physical state of the addicted brain.
+
+Instead of decisions, you need **a system you don't have to think about.**
+
+---
+
+## If-then planning: "if X, then Y"
+
+Psychology research has identified a simple method that dramatically raises how often people hit their goals.
+The name is technical ("implementation intention"), but the practice is simple.
+
+Pre-decide "if X happens, I will do Y."
+
+That's it. Decades of research across health behavior, diet, exercise, studying, chronic disease management, and addiction recovery all show it works.
+
+Why:
+
+- In a crisis, the brain is bad at thinking
+- But it's good at running automatic responses
+- If "if X, then Y" is pre-linked, X triggers Y without a decision
+- "Decision" becomes "automatic"
+
+You're pre-wiring a conditional response, so the crisis moment doesn't need fresh judgment.
+
+---
+
+## Gambling-addiction if-then examples
+
+Concrete examples:
+
+| If (X) | Then (Y) |
+|---|---|
+| I'm about to walk past the casino | Cross to the opposite side of the street |
+| It's the morning of payday | Auto-transfer the paycheck out of checking within minutes of the deposit landing |
+| I'm alone at home in the evening | Send a text to a friend by 7 p.m. |
+| A craving has lasted more than 10 minutes | Leave the house and walk for 10 minutes |
+| Two of my HALT items are hitting | Go to bed early that night |
+| Empty time opens up after drop-off | Leave the house and spend it at a coffee shop |
+| I'm about to open a betting app | Put the phone in another room, open a book in the living room |
+
+Two things to remember:
+
+1. **X should be a specific condition**
+   - No: "if I feel risky" (too vague)
+   - Yes: "Sunday morning with no plans" (specific)
+
+2. **Y should be a concrete action your body can do**
+   - No: "change my mindset" (not a behavior)
+   - Yes: "put $10 in my wallet and go to a coffee shop" (concrete)
+
+---
+
+## Build your own
+
+Pen and notebook. Go in order.
+
+### Step 1: List triggers from past relapses
+
+Think back to past relapses and write down five situations that triggered them.
+Examples:
+- The day after payday
+- An evening when my partner was traveling
+- A day I bombed a big work thing
+- Empty afternoon after dropping my kid off
+- A day with a lot of month-end bills
+
+### Step 2: Decide a Y (action) for each
+
+For each trigger, pick one "here's what I do."
+Make it concrete. Make it something your body can do.
+
+Examples:
+- Day after payday → morning: drop ATM limit to $60 in the banking app
+- Partner traveling → 6 p.m.: video call my mom
+- Work failure → walk one stop past mine on the way home
+- Empty afternoon → leave the house, work from a coffee shop or library
+- Big-bills day → morning: go over the budget with my partner
+
+### Step 3: Write it down
+
+Put it somewhere visible.
+Fridge, bathroom wall, wallet, phone lock screen.
+In the crisis, it's not "remember" but "see."
+
+### Step 4: Review weekly
+
+After a week of using it, log what worked and what didn't.
+Swap the Y on the ones that didn't.
+
+---
+
+## Conditions for if-then to work
+
+- **X has to be specific**: "when I'm anxious" is weaker than "when Friday passes 8 p.m."
+- **Y has to be something you can start right now**: actions that require supplies or travel have higher friction
+- **If Y involves asking someone, tell them in advance**: "I might reach out in certain moments" is enough
+- **Rehearse in your head**: on calm days, run "if X, then Y" in your head a few times
+- **Doesn't have to be perfect**: start with one
+
+---
+
+## Relationship to HALT and the safety plan
+
+The three skills we've covered so far have different roles.
+
+| Skill | Role |
+|---|---|
+| HALT ([Chapter 11](/en/learn/quit-gambling-today/halt/)) | A sensor for checking your state |
+| If-then plan (this chapter) | A reflex action when a trigger hits |
+| Safety plan ([Chapter 8](/en/learn/quit-gambling-today/safety-plan/)) | Last line when a crisis escalates |
+
+They're not independent. They layer.
+
+- Use HALT to check your state regularly
+- If-then fires automatically when a trigger hits
+- If it still escalates, activate the safety plan
+
+---
+
+## There are moments if-then won't hold
+
+If-then isn't bulletproof.
+On days with especially strong cravings, or when several triggers hit at once, you might not run the plan.
+
+When that happens:
+
+- Don't blame yourself
+- Record that "it didn't hold"
+- Revisit the plan in detail
+- Update: "next time I'll change Y to this"
+
+If-then isn't magic.
+But it's a lot stronger than nothing.
+Standing in the crisis moment with a written plan is different from standing there without one.
+
+
+## References
+
+- Gollwitzer, P.M. (1999). Implementation intentions: Strong effects of simple plans. *American Psychologist*, 54(7), 493-503.
+- Gollwitzer, P.M., & Sheeran, P. (2006). Implementation intentions and goal achievement: A meta-analysis of effects and processes. *Advances in Experimental Social Psychology*, 38, 69-119.
+- Webb, T.L., & Sheeran, P. (2006). Does changing behavioral intentions engender behavior change? A meta-analysis of the experimental evidence. *Psychological Bulletin*, 132(2), 249-268.
+- Marlatt, G.A., & Donovan, D.M. (Eds.) (2005). *Relapse Prevention: Maintenance Strategies in the Treatment of Addictive Behaviors* (2nd ed.). Guilford Press.
+- Adriaanse, M.A., Vinkers, C.D.W., De Ridder, D.T.D., Hox, J.J., & De Wit, J.B.F. (2011). Do implementation intentions help to eat a healthy diet? A systematic review and meta-analysis of the empirical evidence. *Appetite*, 56(1), 183-193.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/legal-options.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/legal-options.md
@@ -1,0 +1,303 @@
+---
+category: "gambling"
+part: "D"
+chapter: 18
+title: "The Entry to Legal Debt Relief"
+required: false
+excerpt: "At the attorney's office. She was in her forties, reviewing the paperwork, her face even."
+updatedAt: "2026-04-22"
+---
+<div class="note">
+
+This chapter is general information. For decisions about your specific case, talk to a consumer bankruptcy attorney or a non-profit credit counselor (NFCC-member agency). Laws and procedures vary by state and change over time; this reflects general practice as of 2026.
+
+</div>
+
+At the attorney's office.
+She was in her forties, reviewing the paperwork, her face even.
+
+"Given your situation, Chapter 7 is probably the best fit."
+
+Something inside me gave way.
+I'd been afraid of the word "bankruptcy" for almost twenty years.
+I couldn't tell my family. I couldn't let my job find out. That's what I'd been sure of.
+
+She kept going.
+"Even when the debt came from gambling, Chapter 7 is usually available. It's a bit more complex, but it can be done."
+"Once the discharge goes through, the debt is gone. You rebuild from there."
+
+On the way home, I walked past a casino.
+My body reacted.
+I didn't go in.
+"Someone who's filing bankruptcy can't go back in tonight," I thought.
+
+---
+
+## What legal debt relief is
+
+In the U.S., several legal options let you restructure or discharge debt.
+The main ones are:
+
+1. **Debt management plan (DMP)**: a non-profit credit counselor negotiates lower interest rates and a structured payoff with your creditors
+2. **Debt settlement**: an attorney or settlement firm negotiates with creditors to accept less than what you owe
+3. **Chapter 13 bankruptcy**: a court-supervised plan to repay some of your debt over 3 to 5 years
+4. **Chapter 7 bankruptcy**: a court process that discharges most unsecured debt
+
+Each has different requirements, effects, and consequences.
+Which one fits depends on your situation.
+The choice is made with an attorney or credit counselor, not alone.
+
+---
+
+## Debt management plan (DMP)
+
+### How it works
+
+A non-profit credit counseling agency (NFCC-member) negotiates with your unsecured creditors to:
+
+- Lower interest rates
+- Consolidate payments into one monthly payment
+- Waive some fees
+
+You pay the agency each month; they distribute to creditors. Typical length: 3 to 5 years.
+
+### Pros
+
+- No court involvement
+- Relatively quick to set up (a month or two)
+- Doesn't count as bankruptcy
+- Creditors typically bring accounts current after consistent on-time payments
+- Cheaper in the long run than full settlement
+
+### Cons
+
+- Principal isn't reduced
+- You generally have to close the enrolled credit cards during the plan
+- Requires stable income to stick to the payments
+- Creditors aren't obligated to accept
+
+### Who it fits
+
+- Debt is moderate
+- You have stable income that can cover a structured payoff in 3 to 5 years
+- You want to avoid bankruptcy
+- You want to keep your credit history from taking the bigger hit of bankruptcy
+
+---
+
+## Debt settlement
+
+### How it works
+
+An attorney or settlement firm negotiates with creditors to accept less than the full balance (e.g., 40 to 60 cents on the dollar).
+You stop paying creditors, put money into a dedicated savings account, and lump-sum settlements are paid from that account.
+
+### Pros
+
+- Principal gets reduced
+- Faster conclusion than a DMP (often 2 to 4 years)
+- Total paid can be significantly less than the full balance
+
+### Cons
+
+- Your credit score drops sharply during the "don't pay" period
+- Creditors may sue during the process
+- Settlement firms charge substantial fees
+- Forgiven debt may be treated as taxable income (talk to a tax professional)
+- Not all creditors negotiate
+
+### Who it fits
+
+- Debt is significant
+- You can't fully repay even with lower interest
+- Bankruptcy is available but you're trying to avoid it
+- You can live with significant credit damage
+
+### Warning about for-profit "debt relief" firms
+
+Many for-profit debt settlement firms charge high fees and under-deliver. An NFCC-affiliated non-profit counselor or a licensed attorney is safer.
+
+---
+
+## Chapter 13 bankruptcy (reorganization)
+
+### How it works
+
+A federal court approves a 3-to-5-year plan to repay part of your unsecured debt from your income.
+Remaining unsecured debt at the end of the plan gets discharged.
+You keep secured assets (house, car) as long as you stay current on the plan.
+
+### Pros
+
+- Can stop a foreclosure or a car repossession
+- Lets you keep a house and a car
+- Debt is often reduced substantially
+- No professional licensing restrictions (doesn't disqualify most jobs)
+- Automatic stay stops creditor collection and lawsuits immediately
+
+### Cons
+
+- Takes 3 to 5 years
+- Attorney fees (several thousand dollars, often paid through the plan)
+- Requires regular income
+- Stays on your credit report for 7 years
+- Public court filing
+
+### Who it fits
+
+- Debt is meaningful (higher than fits a DMP)
+- You have reliable income
+- You want to keep assets (especially a house)
+- You'd rather avoid Chapter 7's asset liquidation
+
+### Gambling-related debt
+
+Chapter 13 is available for gambling-related debt.
+Unlike Chapter 7, there's no "dischargeability" obstacle specific to gambling.
+
+---
+
+## Chapter 7 bankruptcy (liquidation / discharge)
+
+### How it works
+
+A federal court process that **discharges most unsecured debt**.
+Non-exempt assets (above state-specific exemption limits) may be sold by the trustee to pay creditors.
+Takes 4 to 6 months from filing to discharge.
+
+### Pros
+
+- Unsecured debt goes away
+- Collection efforts stop immediately (automatic stay)
+- You get a clean slate to start rebuilding
+- In most cases, you keep everyday assets (primary residence up to state exemption, a modest car, household goods, a retirement account)
+
+### Cons
+
+- Stays on your credit report for 10 years
+- Non-exempt assets can be liquidated
+- Some professional licenses have restrictions (mostly financial industry; does not typically affect most jobs)
+- Public court filing
+- You must pass the "means test" (income below a threshold)
+
+### Who it fits
+
+- Debt is too large to repay
+- Income is low or unstable
+- Monthly payments eat most of take-home pay
+- Daily life has collapsed
+
+### Gambling addiction and Chapter 7
+
+**Gambling-related debt can still be discharged in Chapter 7.**
+
+Two things to know:
+
+1. **"Credit card debt incurred shortly before filing, used for gambling, may be challenged as non-dischargeable"**
+   Specifically, large credit card charges or cash advances in the months before filing can be challenged by creditors under 11 U.S.C. § 523 (fraud/reliance). A good bankruptcy attorney handles this.
+2. **Overall, most gambling-related bankruptcies go through**
+   In practice, the majority of Chapter 7 cases involving gambling debt result in discharge. Document your treatment (GA attendance, therapy, psychiatric care), your awareness, and your commitment to recovery. These help demonstrate good faith to the court.
+
+"Chapter 7 isn't for me" is a decision many people make wrongly. Talk to an attorney first.
+
+---
+
+## Which one fits
+
+Rough guide:
+
+| Situation | Option to consider |
+|---|---|
+| Moderate debt + stable income | Debt management plan or debt settlement |
+| Large debt + stable income + want to keep house | Chapter 13 |
+| Debt unmanageable + low or unstable income | Chapter 7 |
+| Not sure where to start | Non-profit credit counselor (NFCC-member) or legal aid clinic |
+
+This is a rough guide.
+The real decision happens with an attorney or credit counselor.
+Don't pre-decide. Go in open, and decide together.
+
+---
+
+## How to use a non-profit credit counselor
+
+### What they are
+
+Non-profit credit counseling agencies, most affiliated with the NFCC (National Foundation for Credit Counseling), offer free or low-cost advice, budgeting help, and DMPs.
+
+### What they can do
+
+- Free initial consultation
+- Listen to your situation and explain what options fit
+- Refer you to an attorney if legal action is needed
+- Run a DMP if that fits
+- Offer free pre-filing credit counseling (required before filing bankruptcy)
+
+### Opening line example
+
+<div class="worksheet">
+
+Credit counseling agency.
+↓
+"I'd like to talk about debt. This is my first time calling."
+↓
+"What's going on with it?"
+↓
+"I have about $___ of debt, most of it related to gambling. I'm struggling to make the payments."
+↓
+(They'll take it from there)
+
+</div>
+
+You don't have to be polished. Name, situation, what you're struggling with. Those are enough.
+
+---
+
+## How to work with a bankruptcy attorney
+
+### Finding one
+
+- Your state bar association's lawyer-referral service
+- A legal aid clinic (free if you qualify)
+- A local consumer bankruptcy attorney (many offer free initial consultations)
+- The National Association of Consumer Bankruptcy Attorneys (NACBA)
+
+### First consultation
+
+- Bring the debt table you built in [Chapter 17](/en/learn/quit-gambling-today/debt-overview/)
+- Bring recent pay stubs and bank statements if you have them
+- Say "gambling addiction is part of the situation." A good attorney treats this the same way they'd treat any medical condition driving the debt
+- Ask about the fee structure upfront
+
+### On cost
+
+Chapter 7 attorney fees typically run a few thousand dollars. Chapter 13 is higher but often paid through the plan.
+If cash is tight, ask about payment plans or legal aid eligibility.
+
+---
+
+## Legal relief alone isn't enough
+
+Legal debt relief addresses the debt.
+It doesn't address the addiction.
+
+Handle the legal side without handling the addiction, and you'll be back in the same place after discharge.
+
+- Cut off access to money ([Chapter 6](/en/learn/quit-gambling-today/money-access/))
+- Connect to GA or treatment ([Chapter 21](/en/learn/quit-gambling-today/treatment-options/))
+- Rebuild family relationships ([Chapter 19](/en/learn/quit-gambling-today/family/))
+
+Doing both at the same time is what "starting over" actually looks like.
+
+Some attorneys understand gambling addiction and can refer you to treatment and support groups.
+If you say you want to handle the addiction in parallel with the legal work, they'll often make introductions.
+
+
+## References
+
+- U.S. Courts. *Bankruptcy basics*. https://www.uscourts.gov/
+- Federal Trade Commission. *Debt relief and credit repair scams*. https://consumer.ftc.gov/
+- National Foundation for Credit Counseling. https://www.nfcc.org/
+- Consumer Financial Protection Bureau. *Debt management and bankruptcy*. https://www.consumerfinance.gov/
+- American Bar Association. *Bankruptcy basics*.
+- National Association of Consumer Bankruptcy Attorneys (NACBA). https://www.nacba.org/

--- a/apps/lp/src/content/learn/en/quit-gambling-today/mental-health.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/mental-health.md
@@ -1,0 +1,234 @@
+---
+category: "gambling"
+part: "D"
+chapter: 15
+title: "Mental Health and Addiction: Overlapping Struggles"
+required: false
+excerpt: "7 a.m. Getting out of bed took thirty minutes. Every step of getting ready for work, my body felt heavy. On the commute I thought 'eight more hours today,' and I started crying."
+updatedAt: "2026-04-22"
+---
+<div class="note">
+
+This chapter is general information, not a diagnosis. If any of these symptoms concern you, see a psychiatrist or primary care provider.
+
+</div>
+
+7 a.m.
+Getting out of bed took thirty minutes.
+Every step of getting ready for work, my body felt heavy.
+On the commute I thought "eight more hours today," and I started crying.
+
+Talking to people at work is exhausting.
+At lunch, I don't want to see anyone, so I go outside alone.
+Without deciding to, I end up standing in front of a casino.
+Inside, playing slots for two hours, I finally stopped thinking.
+
+"Maybe it's depression." I'd thought it before, but not enough to go to a doctor.
+I believed gambling was the whole problem.
+I believed that without the gambling, I'd be fine.
+
+---
+
+## Addiction doesn't usually travel alone
+
+Gambling addiction often shows up with other mental health conditions.
+
+Research shows that more than half of people with gambling disorder have co-occurring depression, anxiety disorders, ADHD, other addictions, or similar conditions.
+
+In other words, having only gambling addiction is the minority case. Most people with the disorder are carrying at least one other thing.
+This doesn't get talked about much. Even the person affected often doesn't know.
+
+If you believe "the moment I stop gambling, I'll be normal," you miss the other conditions entirely.
+Some people find that depression or anxiety emerges after they stop gambling.
+That's not "it got worse when I stopped." That's "gambling was covering up the other conditions."
+
+---
+
+## Depression and addiction
+
+### Rates
+
+Depending on the study, 25% to 75% of people with gambling disorder also have depression. Somewhere around half is a reasonable working estimate.
+Depression in the general population runs around 10%. The gambling population is clearly higher.
+
+### Signs of depression
+
+If any of the following have lasted two weeks or more, depression may be involved:
+
+- Hard to get up in the morning
+- Nothing feels enjoyable anymore
+- Loss of appetite (or overeating)
+- Can't sleep (or oversleeping)
+- Body feels heavy, easy fatigue
+- Can't focus
+- Self-critical thoughts that won't let go
+- "I want to die" or "I want to disappear" crossing your mind
+- Seeing people is exhausting
+
+Some of these overlap with gambling addiction symptoms.
+So from inside, you can't cleanly separate "addiction symptom" from "depression symptom."
+Separating them is the doctor's job.
+
+### The gambling-depression loop
+
+Depression and gambling reinforce each other.
+
+- Depression drops your mood → you reach for gambling to change how you feel
+- You lose → guilt and shame deepen the depression
+- Depression deepens → you reach for gambling again
+
+Both conditions worsen inside the loop.
+Which came first is often unknowable, but both need treatment.
+
+---
+
+## Anxiety disorders and addiction
+
+### Rates
+
+Roughly 30 to 50 percent of people with gambling addiction also have an anxiety disorder.
+Anxiety disorders include generalized anxiety, social anxiety, panic disorder, PTSD, and others.
+
+### Signs
+
+- Low-level worry about small things won't let up
+- Pounding heart, difficulty breathing, panic episodes
+- Extreme fear of being in public or being judged
+- Avoiding specific places or situations
+- Intrusive memories of a distressing past event
+- Hard to fall asleep, waking in the middle of the night
+
+### The connection
+
+For someone with strong anxiety, the "focused zone" inside gambling is a break from anxiety.
+While gambling, past anxieties and future worries go quiet.
+That's why people with anxiety disorders get especially stuck on gambling.
+
+When you stop, the suppressed anxiety often floods back.
+That period is the hardest, and it's where relapse hits.
+Getting connected to treatment at this stage lets anxiety be treated alongside the addiction.
+
+---
+
+## ADHD and addiction
+
+### Rates
+
+Research has found meaningful overlap between ADHD and gambling disorder.
+Roughly 20 to 40 percent of people with gambling addiction have ADHD or significant ADHD traits.
+The general population rate is a few percent, so this is a large jump.
+
+### Adult ADHD signs
+
+- Trouble sustaining attention, easily distracted
+- Difficulty planning and executing
+- Frequent small mistakes
+- Struggle with waiting
+- Impulsive actions
+- Chasing strong stimulation
+- Intolerance for boredom
+
+### The connection
+
+ADHD brains have particular dopamine signaling patterns.
+Day-to-day life feels understimulating, so stronger stimulation pulls hard.
+Gambling's "immediate results," "strong audiovisual input," and "unpredictability" are especially attractive to an ADHD brain.
+
+Combine that with higher impulsivity, and the brakes are weaker.
+"Just a little" becomes playing to the absolute limit.
+
+ADHD is treatable.
+A specialist evaluates and, as appropriate, combines medication and behavioral therapy.
+Treating ADHD has been shown to help gambling addiction treatment move forward.
+
+---
+
+## Other overlapping conditions
+
+### Other addictions
+
+Many people with gambling addiction carry another addiction too.
+- Alcohol use disorder
+- Nicotine dependence
+- Caffeine dependence
+- Sexual addiction
+- Gaming addiction
+- Compulsive shopping
+
+This reflects a shared "addicted brain" state across conditions.
+Stopping one addiction can shift into another, a pattern sometimes called "addiction swapping."
+
+### Trauma and PTSD
+
+Past trauma (abuse, accidents, military service, major losses) is often in the background of addiction.
+Trauma and addiction are tightly linked. If trauma seems to be in the background for you, look for a psychiatrist, psychologist, or licensed therapist with trauma expertise.
+This book doesn't cover trauma treatment itself, but connecting to care is a big step in recovery.
+
+### Bipolar disorder
+
+Bipolar disorder, with its swings in mood, has been linked to gambling addiction in the research.
+The pull toward gambling often gets especially strong during elevated-mood (manic or hypomanic) phases.
+Bipolar requires evaluation and, in most cases, medication.
+
+---
+
+## Overlapping conditions corner you faster
+
+In the safety-plan chapter ([Chapter 8](/en/learn/quit-gambling-today/safety-plan/)), we said that people with gambling addiction often feel "this is unbearable."
+That feeling deepens when conditions pile up.
+
+Depression keeps you still. Anxiety keeps you from sleeping. Debt won't leave your mind.
+When all of it hits at once, "this is unbearable" moments come more often.
+
+That's why co-occurring conditions need to be treated alongside the gambling.
+Being seen for the whole picture is what reduces the load.
+
+---
+
+## Catching your own signs
+
+### Self-check as an entry point
+
+Simple self-checks can surface overlapping conditions.
+Look at the last two weeks and count how many of these fit:
+
+- □ Hard to get up in the morning
+- □ Nothing feels enjoyable
+- □ Appetite changed (up or down)
+- □ Sleep problems (insomnia or oversleeping)
+- □ Body feels heavy, easy fatigue
+- □ Can't focus
+- □ Self-critical thoughts won't stop
+- □ Being around people is painful
+- □ "I want to die" or "disappear" has crossed your mind
+- □ Restless, unsettled by small things
+- □ Panic symptoms (pounding heart, trouble breathing)
+- □ Intrusive memories of a distressing event
+
+Three or more, or any "want to die" at all, is a reasonable threshold for seeing a psychiatrist or primary care provider.
+
+### Self-checks aren't diagnoses
+
+They're a way in, not a conclusion.
+Diagnoses come from clinicians.
+
+Don't decide "I have depression" from a self-check, and don't decide "I'm fine" from one either.
+If something concerns you, bring it to a clinician.
+
+### "I'm here for gambling" is enough
+
+At a psychiatrist's office or addiction clinic, "I'm here to talk about gambling" is a complete opening.
+The clinician will also evaluate depression, anxiety, and other conditions as part of the intake.
+You don't need to say "I think I might have depression."
+Describe what's happening and let them do their job.
+
+
+## References
+
+- Lorains, F.K., Cowlishaw, S., & Thomas, S.A. (2011). Prevalence of comorbid disorders in problem and pathological gambling: systematic review and meta-analysis of population surveys. *Addiction*, 106(3), 490-498.
+- Petry, N.M., Stinson, F.S., & Grant, B.F. (2005). Comorbidity of DSM-IV pathological gambling and other psychiatric disorders: results from the National Epidemiologic Survey on Alcohol and Related Conditions. *Journal of Clinical Psychiatry*, 66(5), 564-574.
+- Kessler, R.C., Hwang, I., LaBrie, R., Petukhova, M., Sampson, N.A., Winters, K.C., & Shaffer, H.J. (2008). DSM-IV pathological gambling in the National Comorbidity Survey Replication. *Psychological Medicine*, 38(9), 1351-1360.
+- Crockford, D.N., & el-Guebaly, N. (1998). Psychiatric comorbidity in pathological gambling: A critical review. *Canadian Journal of Psychiatry*, 43(1), 43-50.
+- Brewer, J.A., & Potenza, M.N. (2008). The neurobiology and genetics of impulse control disorders: Relationships to drug addictions. *Biochemical Pharmacology*, 75(1), 63-75.
+- Faraone, S.V., Asherson, P., Banaschewski, T., et al. (2015). Attention-deficit/hyperactivity disorder. *Nature Reviews Disease Primers*, 1, 15020.
+- Karlsson, A., & Håkansson, A. (2018). Gambling disorder, increased mortality, suicidality, and associated comorbidity. *Journal of Behavioral Addictions*, 7(4), 1091-1099.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/money-access.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/money-access.md
@@ -1,0 +1,223 @@
+---
+category: "gambling"
+part: "B"
+chapter: 6
+title: "Cutting Off Access to Money"
+required: true
+excerpt: "Payday morning. My phone buzzes. 'Direct deposit received.' The back of my neck went hot. Three days earlier, I'd decided to stop for good."
+updatedAt: "2026-04-22"
+---
+<div class="note">
+
+This chapter is general information. For specific debt or legal questions, talk to a consumer-protection attorney, a non-profit credit counselor (NFCC-member agencies), or a free legal aid clinic in your state.
+
+</div>
+
+Payday morning.
+My phone buzzes. "Direct deposit received."
+The back of my neck goes hot.
+Three days earlier, I'd decided to stop for good.
+
+Just pull $100 out where my wife won't notice.
+$100 is invisible. $100 will be fine.
+I pull it out at the gas station ATM and head to the nearest casino.
+Empty seat at the slots.
+
+By evening, I've burned through $1,000.
+The $100 turned into trip after trip back to the ATM.
+On the drive home, my head is full of static, trying to work out what I'll tell my wife.
+
+I've lived this scene hundreds of times.
+Three days of resolve, erased by one notification.
+
+---
+
+## Why "money first"
+
+As the earlier chapters showed, the addicted brain has weakened brakes.
+Once the craving is running, trying to reason your way out is difficult.
+If you can't reason, take away the ability to act. Make it physically impossible. That's the surest method.
+
+This isn't "restricting your freedom."
+If the money isn't there, you can't bet. It's that simple.
+You're not trying to stop with willpower. You're creating a state where willpower doesn't have to show up at all.
+
+The first few days of quitting matter most. Addiction research consistently shows that the first days after stopping are the most relapse-prone. That's exactly why the cutoffs have to happen the same day you decide.
+
+You're not refusing to trust yourself.
+You're refusing to trust the current state of your brain.
+When the brain heals, you can trust yourself again. This is temporary scaffolding.
+
+---
+
+## What to do tonight (30 minutes)
+
+A list of things to do the same day you decide.
+Doing all of them is ideal. If that's too much, pick one. Each one you close reduces tomorrow's available money.
+
+### Set credit card cash-advance limits to $0
+
+Most credit card apps and websites let you set a cash-advance limit. Drop it to zero on every card.
+Changes sometimes take a day or two to process, but submitting the request already makes it harder.
+
+### Physically destroy or hand over cards you use to gamble with
+
+Cards you've been using for sports betting deposits, online casino deposits, or cash advances at casinos. Cut them up. Give them to a trusted family member. Feed them into a shredder.
+You can still get at a credit line without a physical card, but the friction goes up a lot.
+
+### Lower your daily limits on payment apps
+
+Venmo, Cash App, PayPal, Zelle, Apple Pay, Google Pay. Lower transfer limits, unlink bank accounts, remove cards.
+Many of these can feed directly into gambling apps through peer-to-peer transfers or crypto on-ramps.
+
+### Delete every gambling-related app and shortcut
+
+- Uninstall every sports betting app (DraftKings, FanDuel, BetMGM, Caesars, etc.)
+- Delete casino apps (including social casino games)
+- Delete horse-racing and daily fantasy apps
+- Delete browser bookmarks and saved logins
+- Clear saved passwords in iCloud Keychain or Google Password Manager
+- Unsubscribe from every email list related to gambling
+- Clear your recent-sites history on your phone
+
+You're closing the "just log back in" path.
+
+### Self-exclude from sportsbooks and casinos
+
+Every state that allows online sports betting or casino gambling has a self-exclusion program. Some examples:
+
+- Most state gaming commissions maintain a voluntary self-exclusion list for in-state casinos
+- Online sportsbooks have an in-app "self-exclusion" or "responsible gaming" section. Use it
+- Ban yourself from physical casinos in your area (enrollment is usually a form on-site or through the state gaming board)
+
+Self-exclusion periods range from 6 months to lifetime, depending on the state. Pick at least 1 year.
+
+### Close online casino and offshore book accounts
+
+Offshore online casinos are grey-market or illegal in most U.S. states, but many people with gambling problems use them anyway.
+- Use the account's self-exclusion feature if it has one
+- Remove credit cards and crypto wallets from the deposit method list
+
+---
+
+## Within a week: structural cutoffs
+
+These take a little longer. They reshape your life around not gambling.
+
+### Lower daily ATM withdrawal limits
+
+Most banks let you set daily ATM limits through the app or with a quick call.
+Drop your daily ATM limit to something small, like $60 or $100.
+This alone kills the "back to the ATM seven times in a night" pattern.
+
+### Route your paycheck to an account you can't touch
+
+Ideal: ask your employer to split your direct deposit so most of it lands in a joint account or a spouse/partner's account that you can't access.
+If only your own accounts are available, move to an account where the card is held by someone else and the password is controlled by someone else.
+The point is: by the time you'd check the balance on payday, the money has already moved somewhere out of reach.
+
+### Put cards, checkbooks, and ID with a trusted person
+
+Credit cards, debit cards, checkbooks, any form of ID that a lender can pull up. Everything goes to someone you trust.
+"Everything" matters. If you keep even one card, that card will be the one that gets used.
+
+### Freeze your credit at all three bureaus
+
+In the U.S., you can place a free credit freeze with Equifax, Experian, and TransUnion. With all three frozen, no lender can pull your credit report to approve a new loan, credit card, or BNPL line.
+It's free. It's reversible when you want a legitimate credit check (you unfreeze temporarily, then refreeze).
+This is one of the most effective barriers against opening new lines of credit on impulse.
+
+You can also opt out of pre-approved credit card offers at optoutprescreen.com, which stops the pre-screened mail that can tempt new applications.
+
+---
+
+## Telling your family
+
+When you hand money over to your family, they need to be set up on their end too.
+Walking in and saying "take all my money" without context creates confusion.
+
+### What to tell them
+
+At a minimum, three things:
+
+1. I have a gambling addiction. It's a medical condition
+2. Part of treatment is physically cutting myself off from money
+3. This is embarrassing, but I need your help
+
+You don't need a polished explanation. Short is fine.
+
+### Set ground rules
+
+Handing over the cards isn't enough on its own. Agree on some rules.
+
+- A weekly allowance (lunch, gas, minimal spending money)
+- How often you'll show receipts
+- How unexpected expenses will be handled
+- A regular time to look at the accounts together
+
+This keeps it from feeling like constant surveillance, and reduces your family's load.
+
+### Stay transparent
+
+Share a budgeting app (YNAB, Monarch, Rocket Money, or your bank's own). Hand over receipts.
+Not hiding anything is the first step in repairing the relationship.
+
+---
+
+## When you can't use family
+
+Some people live alone. Some are estranged from family. Some have reasons they can't bring family into this.
+Other options:
+
+- A sponsor or a peer from **GA (Gamblers Anonymous)** can hold your cards
+- Ask the social worker at a treatment center or state problem-gambling program
+- A non-profit credit counselor (NFCC-member agency) can help structure your finances
+- Some banks offer "safe account" or custodial arrangements
+- Ask payroll to split your direct deposit with a trusted third party (some employers will do this)
+- In extreme cases, ask to be paid a portion in cash
+
+"I can't tell my family so I can't do this" isn't true. There's always another option besides family.
+Every option feels embarrassing at first. There are things that matter more than the embarrassment.
+
+---
+
+## Don't leave yourself a back door
+
+"Let me keep one card, just in case."
+"I'll delete the app, but I'm still logged in on the browser, that's fine."
+"I'll give my family 90% of the cards and keep 10% for myself."
+
+Every back door you keep is the first thing the craving reaches for.
+The "just one" card hits its limit within three days.
+The still-logged-in browser is open tomorrow night.
+The 10% in cash is gone by the day after payday.
+
+The reason is simple: the addicted brain is already well-practiced at crossing the last line.
+Full cutoff. No psychological escape route.
+
+Leaving a back door implies you trust the future version of yourself not to betray this plan.
+Given the state of your brain, that future version has a high probability of betraying it.
+A full cutoff isn't a vote of no confidence. It's a response to the scientific reality of how the brain works.
+
+---
+
+## If you already have debt
+
+This chapter is mostly about preventing new debt from here forward.
+If you already have debt, you also need to see and deal with what's there.
+That's the focus of "Facing Your Debt" later in this book.
+
+Three things to know right now:
+
+1. **You don't have to deal with debt alone.** Free legal aid clinics, non-profit credit counselors (NFCC-member agencies), and state bar lawyer-referral services can all help
+2. **There are legal paths through debt.** Debt settlement, Chapter 13 bankruptcy (reorganization), and Chapter 7 bankruptcy (discharge) are all options, each with different conditions and consequences
+3. **Even just knowing your total debt is a step.** A lot of people have let "not knowing" turn into a trap of its own
+
+
+## References
+
+- National Council on Problem Gambling (2023). *Problem Gambling Resources*.
+- Ladouceur, R., Lachance, S., & Fournier, P.M. (2009). Is control a viable goal in the treatment of pathological gambling? *Behaviour Research and Therapy*, 47(3), 189-197.
+- Hodgins, D.C., Stea, J.N., & Grant, J.E. (2011). Gambling disorders. *The Lancet*, 378(9806), 1874-1884.
+- Federal Trade Commission. *Free credit freezes and fraud alerts*. https://consumer.ftc.gov/
+- American Gaming Association. *Responsible Gaming*. https://www.americangaming.org/

--- a/apps/lp/src/content/learn/en/quit-gambling-today/naming-emotions.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/naming-emotions.md
@@ -1,0 +1,283 @@
+---
+category: "gambling"
+part: "E"
+chapter: 22
+title: "Naming Your Emotions"
+required: false
+excerpt: "10 p.m. On the couch, TV on. Nothing in particular has happened today."
+updatedAt: "2026-04-22"
+---
+10 p.m.
+On the couch, TV on.
+Nothing in particular has happened today.
+
+Out of nowhere, the back of my neck went hot.
+What is this, I thought.
+A craving? No. Am I angry? No. What is it.
+
+I scanned my head. Something was there. I couldn't put a word to it.
+Whatever it was kept getting bigger.
+Before I knew it, I was putting my shoes on.
+Walking toward the casino.
+
+On the way back, I kept trying to figure out what I'd been feeling.
+I never did land on it that night.
+
+A few weeks later, on a similar night, a word showed up.
+"Oh, that was loneliness."
+The moment it had a name, it got smaller.
+That night, I didn't put my shoes on.
+
+---
+
+## "I don't know how I feel" and addiction
+
+A lot of people with gambling addiction struggle to put emotions into words.
+This isn't a personality problem.
+It's about how addicted brains work, and often, about the environment you grew up in.
+
+### A brain that stopped using feelings
+
+Gambling happens inside strong stimulation.
+Sound, lights, the swings of win and loss, hours lost to focus.
+There's no need for fine-grained feelings in that state. The stimulation paints over everything.
+
+Do this for years, and the circuits for sensing and naming fine-grained feelings fall out of use.
+The brain weakens what it doesn't use.
+The result: "I don't know how I feel."
+
+### People who can't feel it, act it out
+
+If you can't put a feeling into words, where does the feeling go?
+**It goes into behavior.**
+
+Someone who can't name "lonely" translates loneliness into "I want to gamble."
+Someone who can't name "sad" translates sadness into "I want a drink."
+Someone who can't name "angry" translates anger into snapping at family.
+
+People who can put a feeling into words often don't have to act it out.
+For people who can't, feelings become actions.
+
+This is why naming emotions is a core part of recovery.
+
+### Naming a feeling makes it smaller
+
+Brain imaging studies show this, and I'll leave the technical version out.
+
+When you say in your head "I'm angry right now," the intensity of the anger drops a little.
+When you say "I'm lonely right now," the loneliness gets smaller.
+
+The part of the brain that generates feelings and the part that handles language are different regions. When the language side turns on, the feeling side settles down a little.
+
+Putting a name on a feeling, just by itself, makes it easier to carry.
+You don't have to do anything else. Just the name.
+
+---
+
+## Building a basic emotion vocabulary
+
+Naming feelings requires having words to use.
+A lot of people only use three or four.
+
+"Good," "bad," "pissed off," "tired."
+That's not enough to describe what's actually happening.
+
+Here's a wider set to pull from.
+
+### Happiness family
+
+- Happy
+- Joyful
+- Content
+- Relieved
+- Calm
+- Proud
+- Grateful
+- At ease
+
+### Sadness family
+
+- Sad
+- Lonely
+- Empty
+- Disappointed
+- Resigned
+- Heartbroken
+- Detached
+
+### Anger family
+
+- Irritated
+- Annoyed
+- Angry
+- Fed up
+- Furious
+- Resentful
+- Indignant
+
+### Fear family
+
+- Anxious
+- Scared
+- Worried
+- Tense
+- Panicking
+- Dread
+
+### Shame family
+
+- Embarrassed
+- Ashamed
+- Guilty
+- Self-loathing
+- Like I want to disappear
+
+### Other
+
+- Bored
+- Exhausted
+- Unmotivated
+- Confused
+- Numb
+
+That's thirty-plus right there.
+"Annoyed" and "fed up" aren't the same.
+"Sad" and "empty" aren't the same.
+"Anxious" and "panicking" aren't the same.
+
+The more you can tell differences between close-but-different feelings, the higher the resolution gets.
+Higher resolution means fewer times you have to act something out instead of feeling it.
+
+---
+
+## Practice noticing
+
+### Three times a day, ask yourself
+
+Using the vocabulary takes practice.
+Three times a day, at set moments, ask.
+
+Morning, afternoon, evening.
+Pick the times: before meals, during your commute, before bed.
+
+Three questions:
+
+- "What am I feeling right now?"
+- "Is there something in my body I can notice?"
+- "What's running in my head?"
+
+Answer each in one or two words.
+Journal it, or keep it in your head.
+
+### "I don't know" is a valid answer
+
+At first, the only thing you can say is "nothing" or "I don't know."
+That's fine.
+"Nothing" is itself an answer.
+
+Keep going, and slowly more words show up.
+A week in, a month in, your resolution rises.
+
+### Watch your body too
+
+Feelings show up in the body.
+- Tight neck → tension, stress
+- Hot chest → anger, excitement
+- Heavy stomach → anxiety
+- Lump in your throat → grief, shame
+- Light body → happiness, relief
+
+Body sensations let you pick up feelings the head can't name.
+
+---
+
+## Using it during a craving
+
+Emotion naming also helps when a craving arrives.
+"I don't know why, but I want to gamble" shows up. Stop.
+Ask yourself:
+
+"What am I actually feeling?"
+
+Think about it.
+- Lonely?
+- Angry?
+- Bored?
+- Anxious?
+- Tired?
+- Numb?
+
+When a word lands, plan a non-gambling response to that feeling.
+- Lonely → text someone
+- Angry → walk, write it out
+- Bored → start a different activity
+- Anxious → write out what I'm anxious about
+- Tired → sleep
+
+What looked like "I want to gamble" often turns out to be a different need.
+Meet the actual need, and the gambling pull often disappears.
+
+This is the same logic as the HALT from [Chapter 11](/en/learn/quit-gambling-today/halt/).
+HALT is four. Emotion naming is broader.
+
+---
+
+## A daily routine for naming feelings
+
+### Morning check-in
+
+When you wake up, ask one question for one minute.
+"How am I right now?"
+Answer in one or two words.
+Journal it or keep it in your head.
+
+### After-event check-in
+
+When something happens during the day, ask right after.
+"What did that just make me feel?"
+You don't have to answer immediately. Three minutes later is fine.
+
+### Evening review
+
+Before bed, look back at the day.
+"What kinds of feelings came up today?"
+Two or three words.
+
+### Weekly review
+
+On the weekend, look back on the week.
+"What was the strongest feeling I had this week?"
+"When was the hardest moment?"
+"When was the easiest?"
+
+Write it in a notebook.
+A month in, three months in, you start seeing your own patterns of feeling.
+
+---
+
+## Don't sort feelings into "right" and "wrong"
+
+Feelings are not right or wrong.
+What you feel is a fact.
+
+"I shouldn't be angry about this."
+"It's weird that I'm sad about this."
+"I don't get to feel happy in my situation."
+
+These judgments get in the way of naming.
+At the naming step, don't judge.
+Just note "I'm feeling this."
+
+If judgment shows up, write that down as a feeling too.
+"I'm feeling that I want to reject what I'm feeling."
+That counts, too.
+
+
+## References
+
+- Lieberman, M.D., Eisenberger, N.I., Crockett, M.J., Tom, S.M., Pfeifer, J.H., & Way, B.M. (2007). Putting feelings into words: Affect labeling disrupts amygdala activity in response to affective stimuli. *Psychological Science*, 18(5), 421-428.
+- Torre, J.B., & Lieberman, M.D. (2018). Putting feelings into words: Affect labeling as implicit emotion regulation. *Emotion Review*, 10(2), 116-124.
+- Pennebaker, J.W. (1997). *Opening Up: The Healing Power of Expressing Emotions*. Guilford Press.
+- Kashdan, T.B., Barrett, L.F., & McKnight, P.E. (2015). Unpacking emotion differentiation: Transforming unpleasant experience by perceiving distinctions in negativity. *Current Directions in Psychological Science*, 24(1), 10-16.
+- Khantzian, E.J. (1997). The self-medication hypothesis of substance use disorders: A reconsideration and recent applications. *Harvard Review of Psychiatry*, 4(5), 231-244.
+- Greenberg, L.S. (2002). *Emotion-Focused Therapy: Coaching Clients to Work Through Their Feelings*. American Psychological Association.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/near-miss.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/near-miss.md
@@ -1,0 +1,93 @@
+---
+category: "gambling"
+part: "A"
+chapter: 3
+title: "The Near-Miss Trap: How 'Almost Won' Tricks Your Brain"
+required: false
+excerpt: "Late afternoon. Two hours on the slots. $300 gone, and I still couldn't get up from the machine. All day, 'almost' kept happening. Two symbols lined up, the third didn't."
+updatedAt: "2026-04-22"
+---
+Late afternoon. Two hours on the slots. $300 gone, and I still couldn't get up from the machine.
+
+All day, "almost" kept happening. Two symbols lined up, the third didn't. My head knew it was a loss. My body wouldn't move. "The next one is coming" sat in me like a physical weight.
+
+Driving home, I realized something. Every spin had been a loss, but I'd felt "so close" again and again. Somehow, that feeling kept me lifted. Losing had given me a strange kind of satisfaction.
+
+---
+
+## What a near-miss is
+
+A near-miss is, formally, a loss that "came close to a win."
+
+- Two slot symbols lining up, the third one off
+- A four-leg parlay missing by one leg
+- A game where you bet the over, and it missed by a point
+- A horse losing by a head
+
+These are all losses. But inside your brain, they don't register as plain losses. They set off a reaction much closer to an actual win.
+
+---
+
+## What's happening in the brain
+
+Brain imaging studies have shown that when you see a near-miss, dopamine releases at a level close to what happens during an actual win.
+
+In other words, your brain isn't processing the near-miss as a loss. It's processing it as "I was about to get a reward."
+
+The moment of the almost-win fires the reward system. Even though the outcome was a loss, the system stays activated, leaving behind a strong "next one is coming" signal. And so you reach for one more.
+
+A loss starts working like encouragement.
+
+---
+
+## Machines and apps design near-misses on purpose
+
+The almost-wins on slot machines are not accidental. **They're designed.**
+
+The companies that build them know that near-misses push people to keep playing. The overall win probability is fixed by rules, but how often near-miss patterns show up and how dramatic they look is controlled by the designers.
+
+Research has shown that tuning the frequency of near-misses lets operators maximize both time-on-device and money spent. Most slot machines on a casino floor are built around this principle.
+
+The same logic runs inside online casinos and sports betting apps. Near-miss animations, betting slips that show you just missed by a point, push notifications that say "you were X points from winning." None of it is random. It's engineered to make your brain say "the next one is coming."
+
+---
+
+## "Almost" is a trick your brain plays
+
+After a near-miss, thoughts like these appear:
+
+- "The next one's coming"
+- "The streak is about to turn"
+- "It'd be stupid to quit now"
+- "Just one more try"
+
+These are all tricks your brain is playing on you.
+In fact, nothing about the probability has changed.
+No matter how many near-misses have happened, the odds of hitting on the next spin are the same as the first one.
+
+Feeling like "it's about to hit" after a streak of misses comes from the fact that the human brain is bad at processing randomness.
+This is a classic cognitive distortion called the gambler's fallacy, covered in detail in [Chapter 12](/en/learn/quit-gambling-today/cognitive-distortions/).
+
+---
+
+## How to break out of the trap
+
+There are a few practices that help.
+
+First, when a near-miss happens, say "that's a loss" out loud or in your head. Just that one word. It switches your brain over to recognizing a loss before "the next one's coming" takes hold.
+
+Second, count. At the end of a session, tally how many near-misses you had, and how many of those turned into wins. In almost every case, the vast majority were losses. Seeing the actual number thins out the feeling of "the next one's coming."
+
+Third, leave before a near-miss happens. This is the most reliable method. Once you're on the floor or in the app, near-misses are guaranteed. Don't try to outthink the trap. Stay out of it.
+
+Fourth, remember the near-miss is designed. Knowing this by itself gives you a little resistance. The more often you can catch yourself thinking "this machine was built to make me feel this way," the more chances you have to change what you do next.
+
+
+## References
+
+- Clark, L., Lawrence, A.J., Astley-Jones, F., & Gray, N.A. (2009). Gambling near-misses enhance motivation to gamble and recruit win-related brain circuitry. *Neuron*, 61(3), 481-490.
+- Clark, L. (2010). Decision-making during gambling: an integration of cognitive and psychobiological approaches. *Philosophical Transactions of the Royal Society B*, 365(1538), 319-330.
+- Côté, D., Caron, A., Aubert, J., Desrochers, V., & Ladouceur, R. (2003). Near wins prolong gambling on a video lottery terminal. *Journal of Gambling Studies*, 19(4), 433-438.
+- Parke, J., & Griffiths, M.D. (2007). The role of structural characteristics in gambling. In G. Smith, D. Hodgins, & R. Williams (Eds.), *Research and Measurement Issues in Gambling Studies* (pp. 211-243). Academic Press.
+- Dixon, M.R., MacLin, O.H., & Daugherty, D. (2006). An evaluation of response allocations to concurrently available slot machine simulations. *Behavior Research Methods*, 38(2), 232-236.
+- Habib, R., & Dixon, M.R. (2010). Neurobehavioral evidence for the "Near-Miss" effect in pathological gamblers. *Journal of the Experimental Analysis of Behavior*, 93(3), 313-328.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/not-willpower.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/not-willpower.md
@@ -1,0 +1,83 @@
+---
+category: "gambling"
+part: "A"
+chapter: 1
+title: "Gambling Addiction Isn't About Willpower"
+required: false
+excerpt: "1 a.m., standing at the ATM inside a gas station. The screen reads $12. Next paycheck is a week away."
+updatedAt: "2026-04-22"
+---
+1 a.m., standing at the ATM inside a gas station. The screen reads $12. Next paycheck is a week away.
+
+"How did I get here again?" I kept saying in my head. I couldn't explain, even to myself, why I'd walked back into the sportsbook earlier that night. It must have been the hundredth time I left one of those places saying "I'm done."
+
+Was my will weak? Was something wrong with my character? I wanted to go back and lecture the version of me who walked in the first time.
+
+When you reach this point, most people arrive at the same conclusion: "This is about will, or about who I am." That conclusion is wrong by current medical understanding.
+
+**It's not about character or grit. It's about what's happening inside your brain.**
+
+---
+
+## Gambling addiction is a medical disorder
+
+Gambling was officially reclassified as an addiction more recently than most people realize. In 2013, when the American Psychiatric Association revised its diagnostic manual, gambling disorder was moved out of the "impulse control disorders" category (where it sat alongside things like shoplifting and arson) and into the same category as alcohol and drug addictions. In 2019, the World Health Organization did the same.
+
+Why? Because two decades of brain research showed that the gambling brain changes in the same regions, through the same mechanisms, as the alcohol-dependent brain or the cocaine-dependent brain. Biologically, what's happening inside the brain during gambling, drinking, or cocaine use looks remarkably similar.
+
+In the United States, roughly 1% of adults (about 2.5 million people) meet criteria for severe gambling problems, and another 5 to 8 million have mild or moderate problems. Since 2018, when the Supreme Court struck down the federal ban on sports betting and opened the door for states to legalize, gambling access has expanded dramatically. Sports betting apps, online casinos, and daily fantasy sites are now available in most states, twenty-four hours a day, from the phone in your pocket. The problem is growing, and the National Council on Problem Gambling and state health departments treat it as a public health issue, not a character flaw.
+
+---
+
+## What's happening inside the brain
+
+When you gamble for years, your brain physically changes. This isn't about personality or willpower. It's cellular. The way your neurons work shifts.
+
+The change has three main parts.
+
+The first is that dopamine gets released too easily. Dopamine normally fires when you do something your body needs to survive: eating, moving, connecting with people. It creates the sensation of "I want this" or "I want more." In gambling addiction, dopamine fires 1.5 to 2 times harder than normal in response to anything linked to gambling: the sound of a slot machine, the DraftKings logo, the countdown to kickoff. Think of it as a gas pedal that gets pressed on its own.
+
+The second part is that the brakes stop working. The prefrontal cortex, the part of the brain just behind your forehead, handles impulse control. It's the part that says "stop here." In gambling addiction, its activity drops by 20 to 30 percent, according to multiple studies. You may feel like you're pressing the brakes, but they barely engage.
+
+The third part is that specific cues become triggers. The sound of slot machines. The buzz of a push notification. The logo of a betting app. The smell of a casino floor. The graphics of a fantasy-sports lineup. Your brain learns to treat all of these as "a reward is about to arrive." Just seeing or hearing them fires the gas pedal, whether you've decided to stop or not.
+
+These three things don't happen separately. They happen at the same time. The gas pedal is pressed hard, the brakes barely work, and cues keep arriving. A brain in that state cannot be controlled by thinking "I'll stop." **This isn't a story about the strength of your will.**
+
+---
+
+## Why gambling
+
+Not everyone who gambles develops an addiction. Certain forms of gambling are much more addictive than others, and the conditions that make them addictive are well understood. There are four main ones.
+
+First, you don't know when you'll win. Rewards that arrive unpredictably drive behavior more powerfully than rewards on a fixed schedule. Slot machines, online casinos, and in-play sports betting run on this principle. You might win, you might not. That uncertainty is what pushes the gas pedal hardest.
+
+Second, the result comes fast. A single spin is over in seconds. The next one starts immediately. Your brain can run the "bet, result, bet again" loop hundreds of times in an hour, thousands in a day. Horse racing runs a race every half hour. State lotteries draw once a week. Slots and online sportsbooks run orders of magnitude faster, which is why they hook people faster.
+
+Third, "almost won" comes up constantly. Two matching symbols on a slot. A fantasy team missing by one point. A four-leg parlay that cashed three legs. These are all losses, but your brain processes them closer to wins than to losses. The sense of "I was so close" lingers, and that lingering becomes the motivation to try again.
+
+Fourth, it's within reach physically and at any hour. Mobile sports betting has been legalized in most states in the last several years. Online casino apps, social casino games, and scratch-off tickets at every corner store put gambling inside your phone or inside your commute. The distance between "I want to" and "I'm doing it" is essentially zero.
+
+When all four conditions line up, a form of gambling is built to change your brain. Just like alcohol or tobacco, there's individual variation. But when the conditions line up, for most people it's a matter of probability, not character, that at some point they can't stop.
+
+---
+
+## The brain changes back
+
+I've been writing about the brain physically changing. That change is not permanent.
+
+Your brain adapts to how you use it. Keep gambling, and the brain takes a gambling shape. **Keep abstaining, and it slowly moves back.** In both substance and behavioral addictions, extended abstinence has been shown to let brain function recover, in study after study.
+
+Which functions recover, and how long it takes, we'll come back to in later chapters. For now, it's enough to know: the brain can change back.
+
+
+
+## References
+
+- American Psychiatric Association (2013). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed.). American Psychiatric Publishing.
+- World Health Organization (2019). *International Classification of Diseases, 11th Revision (ICD-11)*. https://icd.who.int/
+- National Council on Problem Gambling (2023). *Problem Gambling in the United States*.
+- Volkow, N.D., Koob, G.F., & McLellan, A.T. (2016). Neurobiologic Advances from the Brain Disease Model of Addiction. *New England Journal of Medicine*, 374(4), 363-371.
+- Potenza, M.N. (2014). The neural bases of cognitive processes in gambling disorder. *Trends in Cognitive Sciences*, 18(8), 429-438.
+- Calado, F., & Griffiths, M.D. (2016). Problem gambling worldwide: An update and systematic review of empirical research (2000-2015). *Journal of Behavioral Addictions*, 5(4), 592-613.
+- Clark, L., Lawrence, A.J., Astley-Jones, F., & Gray, N.A. (2009). Gambling near-misses enhance motivation to gamble and recruit win-related brain circuitry. *Neuron*, 61(3), 481-490.
+- Skinner, B.F. (1953). *Science and Human Behavior*. Macmillan.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/payday-survival.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/payday-survival.md
@@ -1,0 +1,205 @@
+---
+category: "gambling"
+part: "B"
+chapter: 7
+title: "Surviving Payday"
+required: false
+excerpt: "Day 20 quit. Lunch break. I opened my banking app in the bathroom stall at work. My paycheck had landed. The usual number. Rent, utilities, the credit card payment."
+updatedAt: "2026-04-22"
+---
+Day 20 of being quit. Lunch break. I opened my banking app in the bathroom stall at work.
+
+My paycheck had landed. The usual number. I looked at the screen and my finger stopped. Rent, utilities, the credit card payment. I did the math in my head. What was going to be left.
+
+"Just $200." The voice showed up. "Just enough to win back what I lost last month."
+
+That afternoon, I opened my phone three times. Not the banking app. The browser, trying to find the sportsbook bookmark I'd supposedly deleted. After work, without quite deciding to, I was standing in front of a casino.
+
+---
+
+## Why payday is the most dangerous day
+
+For someone with gambling addiction, payday is the most dangerous day of the month.
+Three reasons.
+
+### The money is there
+
+As covered in the previous chapter, access to money is the single biggest predictor of behavior.
+On payday, your account is at its highest balance of the month.
+The brain's brakes are especially weak in the presence of available money.
+
+### The direct-deposit notification is a trigger
+
+The "your deposit has arrived" text or push notification isn't just information.
+For the addicted brain, it's a strong cue.
+It triggers a dopamine release on par with a casino sign or the sound of a slot machine.
+
+Every month, every year, if you've gambled on payday, your brain has linked those two things tight together.
+The notification arrives, and your body responds before you've thought about it.
+
+### "Just this month"
+
+Early in the month, the rent hasn't come out, utilities haven't come out.
+The account shows a full month's worth of money, and it feels like slack.
+"Just a little, the month just started" is easiest to tell yourself on payday.
+
+What that "a little" actually does is break next month. But the payday brain isn't looking that far ahead.
+
+---
+
+## The day before payday
+
+Trying to fix a dangerous day "during the day" is hard.
+The day before, you set things up so that the "you" who shows up on payday can't move.
+
+### Route the deposit to an account you can't touch
+
+Best case: change the direct deposit destination to a joint account or a partner's account. Payroll can usually process this in a pay cycle.
+If only your own accounts are available, use an account where the card and password live with someone else.
+
+"Money arrives, I can't touch it." That's the state you want.
+
+### Set up auto-transfers
+
+Most banks let you schedule transfers to run the moment a deposit arrives.
+When the deposit hits, split it automatically:
+
+- Rent and utilities to the bill-pay account
+- Groceries and personal spending to a separate account
+- Everything else to an account you can't access
+
+The point is: the money leaves your reach within minutes.
+The window where "there's money in here" exists should be as short as possible.
+
+### Fill the day's schedule
+
+Don't leave empty blocks on payday. No empty lunch, no empty evening.
+- Lunch: go with a coworker (don't go out alone)
+- Evening: dinner with family, or dinner at home with people
+- If no evening plans: schedule the gym, a walk, a run
+
+Empty time plus money in your account is the most dangerous combination.
+Kill at least one of those two every payday.
+
+### Turn off deposit notifications
+
+In your bank app settings, turn off the direct-deposit push notification.
+If the notification doesn't fire, the cue doesn't fire.
+You can check at night, with your partner, that the deposit came in.
+
+---
+
+## The day itself
+
+### Wake up aware it's payday
+
+Tell yourself, out loud or on paper, "today is payday. My brain will react. I'll be careful."
+It's a small move, but naming it changes what your brain does next.
+
+### Don't be alone at lunch
+
+Lunch alone increases the chance you walk past something that triggers you.
+Eat with a coworker if possible. If that's not possible, eat at your desk.
+
+### Change your route home
+
+If your usual commute passes a casino or a sportsbook, take a different route on payday.
+Get off one stop early and walk. Take a different highway. Drive through a different neighborhood.
+Just changing the path cuts cues.
+
+### Spend the evening with people
+
+Don't create alone time at home.
+If you have family: eat dinner together.
+If you live alone: make plans with a friend or someone from GA.
+If you know nobody's available: go sit in a library or a diner instead of being alone at home.
+
+"Payday, evening, alone" is the combination that breaks people the most.
+
+---
+
+## The day after payday
+
+You're still not safe.
+The deposit has cleared, money is visible in accounts for another day or two.
+
+### Check your balance in the morning with someone
+
+Verify that the auto-transfers ran correctly. Do it with your partner, not alone.
+When you look alone, "there's still a little left, so it's fine" can creep back in.
+Having another set of eyes there stops that.
+
+### Take your weekly allowance in cash
+
+If your spending is on a family-managed system, take that week's allowance in cash the day after payday.
+Not a debit card, not a transfer. Cash.
+Cash visibly shrinks as you spend it. You can feel the limit physically.
+
+### Keep the next evening full too
+
+No empty blocks the day after payday either.
+Same as payday: people, plans, activity.
+
+---
+
+## A morning routine
+
+Independent of payday: a small morning routine every day protects the judgment you have that day.
+Think of it as warming up the brakes in your brain before the day starts.
+
+### Examples
+
+Pick one in the morning (more is better).
+
+- **A morning walk**: 10 minutes as soon as you're up. Around the block is enough. Sunlight and movement together reset the brain
+- **A quick spending check**: look at what you spent yesterday. One minute. Just enough to make spending conscious
+- **Breakfast with family**: five minutes of conversation over coffee
+- **Write today's plan**: one line for lunch, one line for evening. Fill in the empty time
+- **Note on yesterday**: one line confirming you made it through
+- **A note to yourself**: "today I'll rely on the system, not my will"
+
+Less than five minutes is fine.
+What matters is "every morning, without fail."
+Once it's a habit, your body does it without deciding to.
+
+### Why morning
+
+The morning brain has the best-recovered brakes of the day. A night of sleep rebuilds the prefrontal cortex's control. Daytime and evening drain it.
+
+Use that morning brain to set the day: what you'll do, what times are risky, what you'll do if they arrive.
+Then, during the day, just run the plan.
+Don't ask the evening version of you to make decisions. The evening brain is tired and easy to push over.
+
+Five minutes in the morning can save an entire evening from collapsing.
+
+---
+
+## Automate, don't decide
+
+If I had to summarize this chapter in one word: automate.
+
+- Auto-split the deposit
+- Notifications off
+- Weekly lunch with a coworker
+- Morning walk as habit
+- Fixed commute home
+- Weekly money check-in with your partner
+
+All of these are about "not needing to decide in the moment."
+
+The addicted brain is bad at making decisions under pressure.
+Build the plan on calm days, so that on hard days, there's nothing to decide.
+
+Willpower runs out.
+Systems don't.
+Lean on the system.
+
+
+## References
+
+- Battersby, M., Tolchard, B., Scurrah, M., & Thomas, L. (2006). Suicide ideation and behaviour in people with pathological gambling attending a treatment service. *International Journal of Mental Health and Addiction*, 4(3), 233-246.
+- Wood, W., & Neal, D.T. (2007). A new look at habits and the habit-goal interface. *Psychological Review*, 114(4), 843-863.
+- Duhigg, C. (2012). *The Power of Habit: Why We Do What We Do in Life and Business*. Random House.
+- Thaler, R.H., & Sunstein, C.R. (2008). *Nudge: Improving Decisions About Health, Wealth, and Happiness*. Yale University Press.
+- Baumeister, R.F., & Tierney, J. (2011). *Willpower: Rediscovering the Greatest Human Strength*. Penguin Press.
+- Marlatt, G.A., & Donovan, D.M. (Eds.) (2005). *Relapse Prevention: Maintenance Strategies in the Treatment of Addictive Behaviors* (2nd ed.). Guilford Press.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/personal-map.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/personal-map.md
@@ -1,0 +1,277 @@
+---
+category: "gambling"
+part: "E"
+chapter: 24
+title: "Drawing Your Personal Map"
+required: false
+excerpt: "A blank sheet of paper on the desk. In the middle, I drew a circle and wrote 'me.'"
+updatedAt: "2026-04-22"
+---
+A blank sheet of paper on the desk.
+In the middle, I drew a circle and wrote "me."
+
+Around it, I started writing: clinicians, family, helplines, support groups, emergency resources.
+Next to each one, I wrote phone numbers or names.
+
+I stepped back and looked at the finished sheet.
+One page of paper held the whole network of support around me.
+"If something happens, I can reach here." It was right in front of me.
+
+Until that moment, all of this information had been scattered across my head in separate pieces.
+Scattered, it felt like "there's nothing."
+Put on one page, it turned out there was more than I'd thought.
+
+---
+
+## Why put it on a map
+
+Recovery needs a lot of information.
+- Numbers for clinicians
+- Helplines
+- Support group meeting times
+- An attorney or credit counselor
+- Family and trusted friends' numbers
+- Emergency resources
+
+Each one has come up somewhere earlier in this book.
+Kept scattered, though, you don't know where to look in a crisis.
+
+The crisis brain is bad at searching.
+You don't have the capacity to type "problem gambling counselor" into a search bar.
+You don't have the capacity to pull up contact numbers from memory.
+
+So you put it all on one sheet of paper, made in calm hours.
+In a crisis, you just look at the sheet.
+No thinking. No searching.
+
+That's the personal map.
+
+---
+
+## Five things to include
+
+Five sections:
+
+1. Medical
+2. Helplines and community
+3. Support groups
+4. Legal and financial
+5. Personal contacts
+
+Going through each.
+
+### Medical
+
+- Your psychiatrist, therapist, or addiction specialist
+- Name, address, number, hours
+- How to make appointments (call, web)
+- Your primary clinician's name, if you have one
+- Urgent-care or after-hours options for psychiatric care
+
+### Helplines and community
+
+- State problem gambling council
+- County or community mental health center
+- Each of their phone numbers and hours
+- The Suicide & Crisis Lifeline (24/7)
+- The Crisis Text Line (text-based, 24/7)
+- The National Problem Gambling Helpline (24/7)
+
+### Support groups
+
+- Your nearest GA meetings
+- Meeting locations, days, times
+- Contact info (if any)
+- Gam-Anon (for family)
+- Online communities like QuitMate
+
+### Legal and financial
+
+- A non-profit credit counselor (NFCC-member agency) you've talked to
+- Your bankruptcy attorney or legal aid clinic
+- The joint account information (if money is being managed with family)
+- Credit bureaus for freeze management (Equifax, Experian, TransUnion)
+
+### Personal contacts
+
+- Family numbers (the key people)
+- Three trusted friends' numbers
+- GA peers (if any)
+- Mark one "can call in the middle of the night" person
+
+---
+
+## How to build it
+
+### Step 1: Paper and pen
+
+One sheet of paper and one pen.
+Ideally a few colored pens too (red, blue, black).
+
+### Step 2: Put "me" in the center
+
+Draw a circle in the center. Write "me" inside.
+Or your name.
+That's the center.
+
+### Step 3: Place the five sections around it
+
+Lay out the five sections around the center at even spacing.
+
+<div class="personal-map">
+  <div class="personal-map-item" style="grid-area: top;">
+    <span class="personal-map-label">Medical</span>
+    <ul><li>___ Clinic</li><li>Phone: ___</li></ul>
+  </div>
+  <div class="personal-map-item" style="grid-area: left;">
+    <span class="personal-map-label">Personal contacts</span>
+    <ul><li>___</li><li>Phone: ___</li></ul>
+  </div>
+  <span class="personal-map-center" style="grid-area: center;">me</span>
+  <div class="personal-map-item" style="grid-area: right;">
+    <span class="personal-map-label">Helplines and community</span>
+    <ul><li>State gambling helpline</li><li>Phone: ___</li></ul>
+  </div>
+  <div class="personal-map-item" style="grid-area: bottom-left;">
+    <span class="personal-map-label">Legal and financial</span>
+    <ul><li>Credit counselor</li><li>Phone: ___</li></ul>
+  </div>
+  <div class="personal-map-item" style="grid-area: bottom-right;">
+    <span class="personal-map-label">Support groups</span>
+    <ul><li>GA at ___</li><li>Every ___</li></ul>
+  </div>
+</div>
+
+### Step 4: Write details under each section
+
+Draw a line from each section and write the specifics.
+
+Example:
+
+<div class="worksheet">
+
+[Medical]
+├ ___ Psychiatry
+│  Phone: ___
+│  Address: ___
+│  Hours: ___
+│  Clinician: Dr. ___
+└ Suicide & Crisis Lifeline
+   24/7
+
+</div>
+
+Fit everything on one page.
+If you can't, shrink the writing or keep only the highest-priority items.
+
+### Step 5: Highlight emergency contacts in red
+
+From your five sections, circle in red the ones you'd call first in a crisis.
+- Crisis resources (Suicide & Crisis Lifeline, emergency services)
+- Urgent-care psychiatric option
+- The one "can call in the middle of the night" person
+
+Red grabs your eye in a crisis moment.
+
+### Step 6: Photograph it and save it
+
+When the paper map is done, photograph it.
+Save it to your phone's photos.
+Consider setting it as your lock screen.
+Keep the paper copy on a wall at home, or in your wallet.
+
+You want it "in front of you" at all times.
+Not "findable if I dig."
+
+---
+
+## Using the map day-to-day
+
+### During a crisis
+
+Open the map first.
+- Strong craving, can't move → call one of your personal contacts
+- "I want to die" thoughts → emergency resources (red) in order
+- Money-related pressure → non-profit credit counselor or attorney
+- Mental health collapse → medical
+
+No thinking. Look, and call what's written.
+
+### On calm days too
+
+Use it outside crises.
+- Review monthly (are contact details still current)
+- Add new contacts as they show up
+- Cross out contacts you no longer use
+- Decide "next thing to try" once (e.g., "visit a GA meeting next month")
+
+The review itself is a check-in on your own state.
+
+### Share with family
+
+When you can, share the map with family.
+They know where to turn if something happens.
+It lowers their load too.
+
+If no family is available, share it with a trusted third party (clinician, social worker).
+If nobody's there, a map for you alone still works.
+
+---
+
+## Monthly review
+
+### What to check
+
+Pick one day each month to review.
+
+- Have any numbers changed
+- Any new places you want to try
+- Mark places you've actually used
+- Dim places you tried but didn't fit
+- Mark in blue places you want to try next
+
+### Add one new thing each month
+
+Set a goal of adding one new entry each month.
+- Find a new clinic
+- Learn about a new support group
+- Note a new helpline
+- Add one new person you can reach
+
+Small is fine.
+One per month is twelve per year.
+A year from now, the map is full.
+
+### "I have resources" builds up
+
+Doing the monthly review grows the felt sense of having resources around you.
+What started as "nothing" turns, by month six, into "actually, this much."
+
+This is the same movement as recovery capital from [Chapter 23](/en/learn/quit-gambling-today/recovery-capital/) growing in visible form.
+Social capital and part of physical capital ride on this map.
+
+---
+
+## Even with few entries
+
+Some people's maps start mostly empty.
+One contact. No family. No known support group. No clinic yet.
+
+Still worth building. Because:
+
+- "I can add to this" becomes visible
+- Where to add next becomes clearer
+- Even one entry is proof that "something exists"
+
+A mostly-empty map is a list of things to fill in.
+You don't have to complete it up front.
+Write, then add one per month.
+
+
+## References
+
+- White, W. (2008). The mobilization of community resources to support long-term addiction recovery. *Journal of Substance Abuse Treatment*, 36(2), 146-158.
+- Best, D., & Lubman, D.I. (2012). The recovery paradigm: A model of hope and change for alcohol and drug addiction. *Australian Family Physician*, 41(8), 593-597.
+- Humphreys, K., Wing, S., McCarty, D., et al. (2004). Self-help organizations for alcohol and drug problems: Toward evidence-based practice and policy. *Journal of Substance Abuse Treatment*, 26(3), 151-158.
+- Laudet, A.B. (2007). What does recovery mean to you? Lessons from the recovery experience for research and practice. *Journal of Substance Abuse Treatment*, 33(3), 243-256.
+- SAMHSA. *Recovery and recovery support*. https://www.samhsa.gov/

--- a/apps/lp/src/content/learn/en/quit-gambling-today/recovery-capital.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/recovery-capital.md
@@ -1,0 +1,308 @@
+---
+category: "gambling"
+part: "E"
+chapter: 23
+title: "Recovery Capital: What You Already Have"
+required: false
+excerpt: "Walking home from the attorney's office. I'd just finished my third debt settlement meeting. My head was spinning."
+updatedAt: "2026-04-22"
+---
+Walking home from the attorney's office.
+I'd just finished my third debt-settlement meeting.
+My head was spinning.
+
+On the train home, I caught myself thinking:
+"What do I still have?"
+
+Debt, obviously. My job, barely holding. My family relationships, on a thread.
+Once I start counting losses, I can't stop.
+
+I noticed the notebook in my pocket.
+Inside were three weeks of little check marks: days I didn't gamble.
+
+Maybe that counts too, I thought.
+I'd been counting only what I'd lost.
+Things I still have are also on the list.
+
+---
+
+## What recovery capital is
+
+There's a concept in addiction research called "recovery capital."
+It's the sum of everything available to a person recovering from addiction.
+
+It's not just money or things.
+It includes what's inside you, the people around you, the foundations of daily life, beliefs and community. All of it.
+
+Research shows people with more recovery capital have more stable recoveries from addiction.
+People with less recovery capital have a harder time.
+
+**Recovery capital isn't fixed.**
+You can grow it.
+Even if one area looks depleted, you can grow another.
+If one category is completely empty, you can build another.
+
+Recovery capital roughly falls into four categories.
+
+1. Internal capital (what's inside you)
+2. Social capital (connections with people)
+3. Physical capital (the foundations of daily life)
+4. Cultural capital (beliefs, values, community)
+
+Taking them in turn.
+
+---
+
+## Internal capital: what's inside you
+
+Internal capital is the resources you already carry.
+These are the easiest to miss, because they don't look like "resources."
+
+### Examples
+
+- Health (physical, mental)
+- What you've learned from past experience
+- Experience of getting through hard things
+- Self-awareness when it shows up
+- Having stuck with something
+- Willingness to learn, willingness to change
+- Moments of stepping back and seeing yourself
+- Ability to put things into words
+- Moments when you can laugh
+- Being able to get up in the morning
+- Being able to eat
+- Being able to go to work
+
+### Recognizing what's "already there"
+
+People with addiction are bad at calling their own internal capital "real."
+The ones who feel "I have nothing" usually have quite a bit.
+
+The fact that you're reading this book is evidence of internal capital.
+The pull to look for something.
+The willingness to consider change.
+The attention span to read this far.
+
+These are already inside you.
+You don't have to build them from zero.
+
+### An internal capital inventory
+
+Write some of these down.
+
+- What state is my body in right now?
+- What's something I've "kept going with" in the past, even when it was hard?
+- What's honestly not bad about me?
+- What do I enjoy? (Even if it was years ago)
+- When did "I want to change" show up recently?
+
+Some of these you can't answer. That's fine.
+The ones you can answer are your current internal capital.
+
+---
+
+## Social capital: connections
+
+Social capital is the people around you.
+Family, friends, coworkers, clinicians, peers in recovery, neighbors, community members.
+
+### Examples
+
+- Immediate and extended family
+- Friends (old friends, current friends)
+- Coworkers, managers, direct reports
+- Clinicians, counselors, social workers
+- Peers in support groups (GA, QuitMate, etc.)
+- Attorneys or counselors helping with debt
+- People from hobbies or interests
+- Neighbors, regulars at local places
+- People you've met online
+
+### "Broken" and "not broken"
+
+Over the course of addiction, relationships break.
+Not all of them. If there's even one thin thread still connected, that's social capital.
+If you genuinely feel zero, count clinicians, counselors, and support group staff as "future social capital."
+
+### Building social capital
+
+Social capital takes time to build, and pays back more stability in recovery.
+Methods have been covered across the book:
+
+- Rebuild with family through actions ([Chapter 19](/en/learn/quit-gambling-today/family/))
+- Ask for help ([Chapter 10](/en/learn/quit-gambling-today/asking-for-help/))
+- Attend GA or support groups ([Chapter 21](/en/learn/quit-gambling-today/treatment-options/))
+- Participate in communities like QuitMate
+
+Once you have one, the second and third get easier.
+
+---
+
+## Physical capital: the foundation
+
+Physical capital is what materially and financially holds your life together.
+Some people are close to zero here. If it's not zero, make sure you see it.
+
+### Examples
+
+- A place to live (owned, rented, with family)
+- A job and income
+- Basics of living (furniture, appliances, clothes)
+- Food, water, hygiene
+- Transportation (a car, a bike, a transit pass)
+- A phone and a laptop
+- Health insurance and basic social supports
+- Some savings, even small
+
+### Even with debt, you have capital
+
+Having debt doesn't cancel physical capital.
+If you have a place to live, a job, and health insurance, those are physical capital.
+Even if things feel like they're trending to zero, name what's still there.
+
+Keep balance between "what's gone" and "what's still here."
+If you only track what's gone, you stop seeing what's still here.
+
+### If physical capital is near zero
+
+Some people have lost the job, the housing, and the insurance.
+When that's the state, use public safety nets.
+
+- State Medicaid for healthcare
+- SNAP (food assistance)
+- State rental or utility assistance programs
+- Homeless services and shelters
+- American Job Centers and state workforce programs
+- County human services
+
+These aren't things "you shouldn't use."
+They are built for people who need them.
+
+See [Chapter 21 (treatment options)](/en/learn/quit-gambling-today/treatment-options/), [Chapter 17 (debt)](/en/learn/quit-gambling-today/debt-overview/), and [Chapter 18 (legal options)](/en/learn/quit-gambling-today/legal-options/) for relevant resources.
+
+---
+
+## Cultural capital: beliefs, values, community
+
+Cultural capital is the values you care about, the beliefs you hold, and the communities you belong to.
+This counts as capital too.
+
+### Examples
+
+- "What kind of person do I want to be" values
+- Beliefs that matter to you
+- Religion, philosophy, a worldview
+- The culture of where you grew up
+- Movies, books, music that speak to you
+- Habits you inherited from family
+- Identities you hold: parent, partner, child, professional
+
+### Cultural capital is "a story that holds you up"
+
+People live inside a sense of "I'm in this kind of story."
+When addiction takes over, that story collapses.
+It shrinks to "I'm an addict, that's all there is to me."
+
+Cultural capital is the presence of other stories.
+- "I'm a parent who shows up for my kids"
+- "I've held down a job"
+- "I'm the kind of person who calms down when I listen to this album"
+- "I've lived by these values"
+
+These stories remember the version of you that existed before addiction took over.
+In recovery, you can return to those stories.
+
+### Noticing cultural capital
+
+Write down things you usually don't put into words.
+
+- What values have I cared about?
+- What did I get obsessed with as a kid?
+- Where do I want to return to, who do I want to see again
+- What can I say about "this is the kind of person I am"
+
+Some people can't write any of these.
+If you can't, build them.
+Cultural capital can also grow from zero.
+
+---
+
+## Taking stock
+
+Using all four categories, take stock of your recovery capital.
+You don't need to fill it all in. Write what you can.
+
+<div class="worksheet-grid">
+<div>
+
+[Internal capital]
+-
+-
+-
+
+</div>
+<div>
+
+[Social capital]
+-
+-
+-
+
+</div>
+<div>
+
+[Physical capital]
+-
+-
+-
+
+</div>
+<div>
+
+[Cultural capital]
+-
+-
+-
+
+</div>
+</div>
+
+When you finish, look at the whole thing.
+Things you thought you didn't have start showing up.
+
+What's empty, you can grow.
+What's there, you can lean on more.
+It's rare for any category to be fully zero.
+
+---
+
+## "What's here" over "what's missing"
+
+The addicted brain likes to emphasize what's missing.
+- Lost money
+- Broken relationships
+- Time that's gone
+- Things you didn't do
+
+The longer your attention sits there, the slower recovery moves.
+Looking at "missing" drains you.
+
+Looking at "what's here" gives some of it back.
+- Today, I ate
+- Today, I talked to someone
+- Today, I didn't gamble
+- Today, I read a page
+
+Small, but on the "here" side.
+Checking "here" every day grows the felt sense of your own recovery capital.
+
+
+## References
+
+- Granfield, R., & Cloud, W. (1999). *Coming Clean: Overcoming Addiction Without Treatment*. New York University Press.
+- Cloud, W., & Granfield, R. (2008). Conceptualizing recovery capital: Expansion of a theoretical construct. *Substance Use & Misuse*, 43(12-13), 1971-1986.
+- White, W., & Cloud, W. (2008). Recovery capital: A primer for addictions professionals. *Counselor*, 9(5), 22-27.
+- Best, D., & Laudet, A.B. (2010). *The Potential of Recovery Capital*. RSA Projects.
+- Laudet, A.B., & White, W.L. (2008). Recovery capital as prospective predictor of sustained recovery, life satisfaction, and stress among former poly-substance users. *Substance Use & Misuse*, 43(1), 27-54.
+- Vaillant, G.E. (2003). A 60-year follow-up of alcoholic men. *Addiction*, 98(8), 1043-1051.
+- Hennessy, E.A. (2017). Recovery capital: A systematic review of the literature. *Addiction Research & Theory*, 25(5), 349-360.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/recovery-exists.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/recovery-exists.md
@@ -1,0 +1,160 @@
+---
+category: "gambling"
+part: "A"
+chapter: 5
+title: "People Do Recover"
+required: false
+excerpt: "What number is this, I thought. Three weeks after telling my wife I was done, I was back at it. Then another three weeks."
+updatedAt: "2026-04-22"
+---
+<div class="note">
+
+Throughout this book, when someone who'd stopped gambling goes back to it, we call that a "relapse" (sometimes also called a "slip" or "lapse").
+
+</div>
+
+What number is this, I thought.
+Three weeks after telling my wife I was done, I was back at it.
+"This time for sure," then another three weeks.
+
+Seven, eight, nine times.
+Each time you say it, their trust drops a little more.
+At some point you stop trusting yourself.
+
+I searched for "gambling addiction recovery" on my phone.
+One post in the community I landed on read:
+
+"29 relapses. 302 days clean now."
+
+29.
+My nine felt small next to that.
+And the fact that this person had 302 days hit me harder than anything.
+
+---
+
+## "It's too late" is not a fact
+
+After enough relapses, most people land on some version of this:
+
+"I've tried and failed enough. I'm not going to stop."
+"Nine attempts, nine failures. Recovery doesn't apply to me."
+"Sure, some people recover. I'm not one of them."
+
+This line of thinking is a natural output of the addicted brain.
+It's also wrong.
+
+What the research actually shows is this: **recovery from gambling addiction is not rare.** A large U.S. survey found that a meaningful percentage of people who once had gambling disorder recovered without formal treatment.
+
+Recovery doesn't just mean "got treatment, got better." A very common pattern is "tried and failed many times, and then one day it stuck."
+
+---
+
+## What the data shows
+
+Let's look at data from QuitMate, an app used by people recovering from addictions.
+
+### The wider picture
+
+Of 1,407 active users (opened the app within the last month):
+
+- **Around 38%** have stayed quit for 90+ days at some point in the past
+- **Around 10%** have hit 365+ days
+
+One in ten is more than a year in.
+And these aren't people who succeeded on the first try. Most of them relapsed repeatedly before this.
+
+### V-shaped recovery
+
+One pattern worth paying attention to is the "V-shaped" recovery:
+
+- At least 3 relapses in the past
+- Currently on a streak 3x longer than their previous average
+- Still going (not past tense, right now)
+
+**59 users** fit this pattern as of April 2026. A few examples (attributes only, to avoid identifying anyone):
+
+- A man (slot machines): **29 relapses**. His past average streak was 3 days. He's now at **302 days**
+- Another man (slots): **16 relapses**. Past average of 4 days. Currently **554 days**
+- Another man (slots): past average of **2 days**. Currently at exactly **365 days**
+- A woman (alcohol, for comparison): 9 relapses, past average 49 days, now at **475 days**
+- Another man (slots): 7 relapses, past average 15 days, now at **535 days**
+
+29 relapses. 16 relapses. Past average of 2 days. Any of these numbers could convince you it's over.
+But the people with these numbers are, right now, still going.
+
+---
+
+## The "something shifts" pattern
+
+Across the V-shaped recoveries, one observation recurs.
+
+**People who relapsed many times, over and over, one day crossed into a long stretch of sobriety.** Up to that day, they were looping the same short cycle. What exactly tipped it over is usually not clear, even to the person it happened to.
+
+Someone who'd been relapsing every two or three days, at some point, starts going 100, 200, 500 days.
+
+This turning point happens to people who have been relapsing over and over. It's real.
+
+The people who made it to long streaks have one thing in common.
+
+**They didn't stop trying.**
+
+During the relapse cycle, it feels like a continuous string of failures. Ten tries, twenty tries, always breaking in a few days. Plenty of them were posting "I'll never recover." Only the ones who tried again were there when the turning point showed up.
+
+The ones who decided "I'm done trying" never met that day.
+
+---
+
+## You don't have to do it alone
+
+Here's another thing the data shows. Connection matters.
+
+In the same dataset, users were grouped by how many comments they got from other users in their first 30 days. Then the rates of staying quit past 90 days were compared:
+
+- 0 comments → **28.6%**
+- 1 to 2 comments → **42.0%**
+- 3 to 9 comments → **50.2%**
+- 10+ comments → **60.8%**
+
+Just feeling like someone is watching, like you're not alone, nearly doubled the probability of staying quit.
+
+---
+
+## Limits of this data
+
+This data has limits.
+
+- **No control group**: no comparison with people who don't use the app
+- **Self-selection**: motivated users are over-represented, so the sample is skewed
+- **Reverse causality is possible**: "the app helped recovery" vs. "people who stayed recovered kept using the app" can't be disentangled. The same limitation applies to the comments-and-retention link
+
+So this isn't proof that "using an app cures addiction."
+
+Even with those limits, **the fact that people who relapsed many times are currently in long recovery doesn't change**. What you make of the numbers is secondary. Those people exist.
+
+---
+
+## What this means for you
+
+"That person made it, so I can too" is not how it usually lands. It's more common to think "they're different, I'm not like them."
+
+The people who hit the turning point didn't think of themselves as special either.
+They also thought "it's too late for me." They thought it many times.
+And they kept going. One day, something shifted.
+
+Whether you recover is not something you or anyone else can predict.
+Exactly because it's unpredictable, the only option is to keep going. It never comes for the people who stopped trying.
+
+
+## References
+
+- QuitMate internal app data (April 2026 analysis). Aggregated via `tools/recovery/recovery.py`. Approximately 8,000 users and 28,000 trials.
+- Slutske, W.S. (2006). Natural recovery and treatment-seeking in pathological gambling: results of two U.S. national surveys. *American Journal of Psychiatry*, 163(2), 297-302.
+- Hodgins, D.C., & el-Guebaly, N. (2000). Natural and treatment-assisted recovery from gambling problems: a comparison of resolved and active gamblers. *Addiction*, 95(5), 777-789.
+- Cunningham, J.A. (2005). Little use of treatment among problem gamblers. *Psychiatric Services*, 56(8), 1024-1025.
+- Marlatt, G.A., & Donovan, D.M. (Eds.) (2005). *Relapse Prevention: Maintenance Strategies in the Treatment of Addictive Behaviors* (2nd ed.). Guilford Press.
+
+<div class="note">
+
+Note: User attributes in this chapter are taken from QuitMate app data, with only category-level information shown in order to avoid identifying individuals. The limitations of the dataset (no control group, self-selection bias, possible reverse causality) are noted above.
+
+</div>

--- a/apps/lp/src/content/learn/en/quit-gambling-today/relapse-not-failure.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/relapse-not-failure.md
@@ -1,0 +1,276 @@
+---
+category: "gambling"
+part: "E"
+chapter: 25
+title: "Rebuilding After a Relapse"
+required: false
+excerpt: "6 a.m. My head is heavy. Last night, three weeks of sobriety ended. I went back to the casino. Lost $300."
+updatedAt: "2026-04-22"
+---
+6 a.m.
+My head is heavy.
+Last night, three weeks of sobriety ended. I went back to the casino.
+Lost $300.
+
+The voices in my head won't shut up.
+"I'm the same person after all"
+"Three weeks for nothing"
+"What do I even tell my family"
+"That's it. Done. I'm stopping everything"
+
+I can't move. Still in bed.
+Open my phone.
+Open the QuitMate app.
+Look at the "reset" button.
+Hit it, or don't.
+
+My hand stops.
+If I hit it, the 21-day streak is gone.
+If I don't, I'm living with a false number.
+
+Both are hard.
+
+---
+
+## Relapse is not rare
+
+Almost nobody recovers from gambling addiction without relapsing at least once.
+This is a well-established finding in addiction research.
+Most people who've "stopped" are people who stopped, went back, stopped again, went back, and kept going.
+
+The data in [Chapter 5](/en/learn/quit-gambling-today/recovery-exists/) backs this up.
+Fifty-nine people in long-term recovery had three or more past relapses.
+"Relapse means it's over" is not true.
+The ones who've stopped are the ones who tried again after relapsing.
+
+---
+
+## The turning point only comes to people who "started again"
+
+- Someone with 29 past relapses is 302 days in today
+- Someone with 16 past relapses is 554 days in
+- Someone with 7 past relapses is 535 days in
+
+Each of these people, on their 29th, 16th, or 7th relapse, felt "this is over."
+They started again anyway.
+And after that "started again," the turning point came.
+
+The turning point arrives only for people who kept trying.
+For people who stopped trying, it never comes.
+
+---
+
+## The emotional wave after a relapse
+
+Right after a relapse, most people go through the same pattern of emotions.
+Knowing the pattern helps you not get swallowed by it.
+
+### Stage 1: Shock
+
+"I did it again." "I failed." "Three weeks gone."
+Your mind goes blank.
+Your body won't move.
+
+Don't decide anything here.
+Not deciding anything is the best choice in this stage.
+
+### Stage 2: Self-attack
+
+"I'm weak." "I'm still an addict after all." "My family doesn't deserve this."
+Self-critical thoughts fill your head.
+
+As [Chapter 20](/en/learn/quit-gambling-today/shame-vs-guilt/) explained, shame reinforces addiction.
+The longer you spend attacking yourself, the closer the next relapse comes.
+
+### Stage 3: Giving up
+
+"Who cares." "Three weeks of effort for nothing." "One more round, same as before."
+If "one more round" wins here, the next relapse chains.
+The moment "three weeks for nothing" lands, you do the same thing again.
+
+This is a classic response in the addicted brain.
+The "give up" mode is the most dangerous window.
+
+### Stage 4: Moving to action
+
+As the wave eases, "I need to do something" starts.
+One small action here, and the recovery restarts.
+
+The four stages take hours to days. Some people, weeks.
+Don't decide "I'm quitting trying" mid-wave. The wave passes. Move once it's passed.
+
+---
+
+## Concrete actions for the day after a relapse
+
+Here's the core of the chapter.
+A list of concrete actions for the day after, or the day after that.
+
+### Action 1: Log the relapse
+
+App, notebook, phone notes, anything.
+Record the fact of the relapse.
+Date, place, money spent, hours.
+
+Logging keeps it from becoming "didn't happen."
+It exists. You move forward from its existence.
+Writing it keeps it from being erased, and lets the next step happen.
+
+### Action 2: Reset the structure
+
+Something in your structure was compromised before the relapse.
+- Money cutoffs had loosened
+- You'd started taking the old commute again
+- Conversations with family had dropped
+- The morning routine had stopped
+- You'd skipped GA
+- You'd missed a treatment appointment
+
+Whatever broke, rebuild it.
+You don't have to rebuild all of it at once.
+Pick one: "in the next week, I'll restore this one."
+
+### Action 3: Tell your family
+
+Tell your family the relapse happened.
+This is hard. You don't want to.
+But hiding it brings the next relapse in faster.
+
+Use the "report" format from [Chapter 19](/en/learn/quit-gambling-today/family/):
+
+> "Last night I relapsed. I spent $___.
+> I'm rebuilding my structure. Specifically, I'm going to ___.
+> I want to ask you to ___."
+
+No apology needed.
+Fact, next action, what you're asking from them. Three lines.
+
+Your family may get angry.
+May cry.
+May go silent.
+All of those are normal reactions.
+Don't wait for a specific reaction. Deliver the report.
+
+### Action 4: Bank visit (or the equivalent)
+
+If the money cutoff had slipped, go with a family member and tighten it again.
+- Drop the ATM daily limit lower
+- Hand the cards back over
+- Confirm the direct deposit destination
+- Restart shared access to the budgeting app
+
+Doing this with family makes it visible.
+Trust returns only through action ([Chapter 19](/en/learn/quit-gambling-today/family/)).
+
+### Action 5: Contact medical or GA
+
+If you've been seeing a clinician, call and move your next appointment earlier.
+If you've been going to GA, make the next meeting without fail.
+If you haven't been connected to either, connect now.
+
+"It's hard to call right after a relapse" is understandable.
+But for clinicians and GA members, a call after a relapse is one of the most important calls you can make.
+"I relapsed and I want to talk" is enough.
+You won't be judged.
+
+### Action 6: Write a review
+
+Once you've had a few days and things have calmed slightly, write a review.
+
+Things to write:
+- What was happening that day
+- What were the triggers (place, people, time, emotion)
+- Add any new triggers to your [trigger map](/en/learn/quit-gambling-today/trigger-map/)
+- Where in your structure was the weak point
+- What will you change for next time the same situation comes up
+
+The review is not for blame.
+It's for building the next set of countermeasures.
+
+### Action 7: Plan the next 7 days
+
+The week after a relapse is a heightened-risk window.
+Write out a plan for those 7 days, one day at a time.
+
+- What time to wake up
+- What to do in the morning
+- What to do for lunch
+- Who to spend the evening with
+- What to do before bed
+
+Don't leave empty blocks.
+Minimize alone time.
+Use routes that don't pass triggers.
+
+---
+
+## Turning relapse into input for the next recovery
+
+### Viewing a relapse differently
+
+The V-shape recoveries shared common shifts in stance:
+
+- Treating relapse as "data" instead of "failure"
+- Calmly analyzing "what was the trigger"
+- Deciding "what I'll do next time in the same situation"
+- Minimizing time spent self-attacking
+- Not hiding from family, clinicians, or support groups
+
+These don't come fast.
+In the first few relapses, you'll self-attack and freeze.
+After a few more, the "treat it as data" muscle starts to develop.
+
+### "I'm weak" becomes "my defenses aren't enough yet"
+
+When a relapse happens, you feel "I'm weak."
+Instead, frame it as "my defenses aren't enough yet."
+
+Big difference.
+
+- "I'm weak" → self-attack, stuck
+- "Defenses aren't enough yet" → build the next defense
+
+Relapse is the result of not enough protection. Not weakness.
+Add one countermeasure, and the gap until the next relapse grows.
+
+### What matters more than frequency: speed of recovery
+
+The sign of recovery isn't "zero relapses."
+It's "how fast you come back."
+
+- Early: relapse leads to weeks or months of gambling
+- As you improve: you can act again the next day
+- Further along: you can stabilize yourself within the same day
+
+Don't track "did I relapse." Track "how fast did I recover."
+If the recovery is getting faster, you're in recovery.
+
+---
+
+## "Recovery isn't a goal, it's a practice"
+
+Everything in this book comes down to this one idea.
+
+Recovery isn't a destination.
+"Fully cured" doesn't arrive for most people.
+Addiction is a condition you maintain in a managed state.
+
+Even so, people do recover.
+Someone with 29 past relapses is 300+ days in.
+Someone who restarted many times is now living a different life.
+
+They're not special.
+They just didn't stop trying.
+
+The people who relapsed and kept going are the ones who get there.
+
+
+## References
+
+- QuitMate internal app data (April 2026 analysis). Aggregated via `tools/recovery/recovery.py`. Approximately 8,000 users, 28,000 trials.
+- Marlatt, G.A., & Donovan, D.M. (Eds.) (2005). *Relapse Prevention: Maintenance Strategies in the Treatment of Addictive Behaviors* (2nd ed.). Guilford Press.
+- Witkiewitz, K., & Marlatt, G.A. (2004). Relapse prevention for alcohol and drug problems: That was Zen, this is Tao. *American Psychologist*, 59(4), 224-235.
+- Hodgins, D.C., & el-Guebaly, N. (2004). Retrospective and prospective reports of precipitants to relapse in pathological gambling. *Journal of Consulting and Clinical Psychology*, 72(1), 72-80.
+- Brandon, T.H., Vidrine, J.I., & Litvin, E.B. (2007). Relapse and relapse prevention. *Annual Review of Clinical Psychology*, 3, 257-284.
+- Kelly, J.F., Stout, R.L., Magill, M., & Tonigan, J.S. (2011). The role of Alcoholics Anonymous in mobilizing adaptive social network changes: A prospective lagged mediational analysis. *Drug and Alcohol Dependence*, 114(2-3), 119-126.
+- DiClemente, C.C. (2003). *Addiction and Change: How Addictions Develop and Addicted People Recover*. Guilford Press.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/safety-plan.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/safety-plan.md
@@ -1,0 +1,292 @@
+---
+category: "gambling"
+part: "B"
+chapter: 8
+title: "When You Want to Die: A Safety Plan"
+required: true
+excerpt: "2 a.m. Lying in bed, staring at the ceiling. That day, my wife had found out the full size of the debt. I can't remember her face. She was crying, I think."
+updatedAt: "2026-04-22"
+---
+<div class="note">
+
+This chapter is about suicidal thoughts. If you're in severe distress right now, please reach out immediately:
+
+- The **Suicide & Crisis Lifeline** (24/7, call or text, in the U.S.)
+- The **Crisis Text Line** (text-based, 24/7)
+- The **National Problem Gambling Helpline** (operated by the National Council on Problem Gambling)
+- If you're in immediate danger, go to your nearest emergency room or call emergency services
+
+This chapter is general information. For specific medical decisions, including whether inpatient care is appropriate, consult a psychiatrist.
+
+</div>
+
+2 a.m.
+Lying in bed, staring at the ceiling.
+That day, my wife had found out the full size of the debt.
+I can't remember her face. She was crying, I think.
+
+I don't have the energy to go to work tomorrow.
+I'm thinking about the life insurance.
+If I were gone, the family would be better off with the payout.
+The moment I thought that, I felt a little bit of calm.
+
+---
+
+## Gambling addiction and suicide
+
+People with gambling addiction are at elevated suicide risk. Studies report a rate 3 to 4 times higher than the general population.
+Roughly half of people with gambling disorder report past suicidal thinking in some surveys.
+Among addictions, gambling disorder carries one of the highest suicide risks.
+
+Reasons consistently cited in the research:
+
+- Financial pressure from debt
+- Collapse of family relationships and work
+- Guilt and shame
+- The moment the hidden truth becomes visible
+- The cognitive distortion: "they'd be better off without me"
+- Co-occurring depression and anxiety
+
+The scene at the top of this chapter is not fiction. Many people with gambling addiction describe something like it.
+The highest-risk moments are typically the hours and days after your family finds out, the day bills arrive, and the period when legal debt processes start moving.
+
+"Wanting to die" is not a personality defect or weakness.
+It's a common symptom of the illness of gambling addiction.
+
+---
+
+## Why "I've decided" isn't enough
+
+Just deciding "I won't do it" is not enough.
+
+In a crisis moment, the brain's brakes (the prefrontal cortex we've discussed) are barely working.
+Judgment, love for your family, none of it functions in that window.
+Instead, the state is dominated by the pull of "I just want this to stop" and the distortion of "they'd be better off without me."
+
+A decision made by a calm brain is real.
+But the decision dissolves in the crisis moment. So instead of a decision, you need a plan.
+
+Decide in advance: "if this sign shows up, I'll do this." Write it down. Keep it where you can see it.
+In the crisis moment, you don't think. You follow what's written.
+This is called a safety plan.
+
+---
+
+## The six steps
+
+The safety plan was systematized in the U.S. in 2012 (Stanley & Brown) and is now a standard tool in suicide prevention worldwide.
+Six steps.
+
+### Step 1: Recognize your warning signs
+
+Write down the signs that say "something is wrong" for you personally.
+If they appear, move to the next step.
+
+Examples:
+- Several days of insomnia
+- Loss of appetite
+- No energy to go to work
+- Not wanting to talk to anyone
+- Thinking about life insurance
+- Replaying moments you'd almost gone through with it
+- A sudden jump in alcohol use
+- "I just want this to stop" on repeat
+
+Write at least five. Writing reveals a pattern.
+
+### Step 2: Things you can do on your own
+
+When the warning signs appear, try something you can do alone first.
+Not "don't think about it." "Do something else."
+
+Examples:
+- Go for a walk (outside air and rhythm shift the brain)
+- Take a shower or a bath
+- Listen to music you love
+- [5-4-3-2-1 grounding](/en/learn/quit-gambling-today/craving-basics/) (same as the craving chapter)
+- Write your thoughts down, messy, uncensored
+- Spend time with a pet
+- Light exercise
+
+Write at least five.
+You're not trying to change how you feel. You're riding out the crisis wave by spending time.
+
+### Step 3: Places and situations that distract you
+
+If you can't stay at home, list places you can go.
+Include places where you don't have to talk to anyone.
+
+Examples:
+- A 24-hour diner or coffee shop
+- A library (daytime)
+- A park
+- A 24-hour grocery store or a busy transit hub
+- A hospital lobby (one with an emergency department)
+
+Being around other people, even without interacting, shifts your brain's state.
+
+### Step 4: People you can call
+
+At least three people you could call or text in crisis.
+Write their names and numbers.
+
+Talk to these people in advance.
+"I might reach out to you at a weird hour someday" is enough.
+You don't need a polished explanation.
+
+How to choose:
+- Someone you won't hesitate to contact
+- Someone who doesn't need the full story to pick up
+- Someone who won't lecture or blame
+- Family, friends, GA members, anyone
+
+### Step 5: Professional and crisis resources
+
+For when family and friends aren't enough.
+
+- Your psychiatrist, therapist, or addiction specialist
+- Your local community mental health center
+- The **Suicide & Crisis Lifeline** (24/7, U.S.)
+- The **Crisis Text Line** (text-based, 24/7)
+- The **National Problem Gambling Helpline** (24/7, confidential, operated by NCPG)
+- Emergency services or the nearest emergency room for immediate danger
+
+Save these in your phone's favorites.
+Also write them on a physical card in your wallet.
+
+### Step 6: Limit access to lethal means
+
+In the crisis moment, not having the means within reach is what saves lives.
+
+Physically move away anything that could be used:
+- Hand extra prescription medication to a trusted person for safekeeping
+- Store or dispose of firearms outside the home (safe storage, a friend's gun safe, a police station, a licensed FFL dealer). This is the single most effective step if you have access to a gun
+- Hand over sharp objects, rope, cords, belts if they've been part of your thinking
+- If you've been thinking about life insurance, hand the policy documents to family
+- If you've been drawn to specific high locations or bridges, plan routes that avoid them
+
+The idea: don't trust the "suicidal you" to keep you safe. Take it out of their hands.
+If the means isn't within reach in the crisis moment, time passes before you can act.
+Once time passes, the wave goes down.
+
+The research is clear: limiting access to lethal means is one of the most consistently effective suicide-prevention methods there is.
+
+---
+
+## In the crisis moment
+
+If you're having thoughts of ending your life right now, go through these in order:
+
+1. **Notice that you're in crisis**
+   Naming the state itself restores a little of your brain's function.
+2. **Open your safety plan**
+   Wallet, phone wallpaper, kitchen wall, wherever you put it. Pull it out.
+3. **Try one thing from Step 2**
+   Any one. Just one.
+4. **If that doesn't help, move to Step 3**
+   Leave the house. Convenience store, coffee shop, gas station, any other place.
+5. **If that doesn't help, go to Step 4**
+   Call the first name on your list. If they don't answer, the second. Keep going.
+6. **If that doesn't help, reach a professional or emergency services (Step 5)**
+   No hesitation. You don't need to explain. "I'm having thoughts of suicide" is enough.
+
+Go through them in order. If one doesn't work, move to the next.
+If nothing works, go to the nearest emergency room, or call emergency services.
+
+---
+
+## When "they found out, and I want to die"
+
+A common pattern in gambling-related suicidal thoughts: debt is discovered, the family falls apart, "I can't live through this."
+The opening scene is one of these moments.
+
+The brain in that state is under strong cognitive distortion.
+**"They'd be better off without me" is almost always wrong.**
+
+### Debt has a path through it
+
+Debt can be resolved. There are legal paths: debt settlement, Chapter 13 bankruptcy (reorganization), Chapter 7 bankruptcy (discharge). Each has different terms and consequences, but all of them exist precisely because people are expected to survive financial collapse and rebuild. Debt does not end your life. That's a fact (covered in [Chapter 17](/en/learn/quit-gambling-today/debt-overview/) and [Chapter 18](/en/learn/quit-gambling-today/legal-options/)).
+
+### Family relationships can rebuild, or other paths open
+
+Family relationships can be rebuilt with time. Rebuilding trust takes a long time, but many people actually do it.
+Even if it doesn't rebuild, your life doesn't end there. Many people have recovered after separation or divorce.
+
+### "They'd be better off without me" is not true
+
+This is the most important one.
+- Life insurance has many restrictions. In many cases, the payout is not what you imagined
+- Families of people who die by suicide carry deep, lasting pain. "Better off" is far from the reality
+- If you have children, the impact on their lives is enormous
+- Family members often carry lifelong self-blame
+
+"They'd be better off without me" is a textbook cognitive distortion of the crisis brain.
+It's understandable that you'd want to believe it. It's not true.
+
+**"They'd be better off without me" is a lie.**
+
+---
+
+## Write your own safety plan
+
+Grab a pen and some paper.
+Fill this in. It doesn't have to be perfect. Getting started is what matters.
+
+### [My Safety Plan]
+
+**1. Warning signs (five or more)**
+
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+
+**2. Things I can do on my own (five or more)**
+
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+
+**3. Places I can go (three or more)**
+
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+
+**4. People I can call (three names with numbers)**
+
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+
+**5. Professional and crisis resources**
+
+- My psychiatrist / therapist: \_\_\_\_\_\_\_\_\_\_
+- Local mental health center: \_\_\_\_\_\_\_\_\_\_
+- Suicide & Crisis Lifeline (24/7)
+- Crisis Text Line (text-based, 24/7)
+- National Problem Gambling Helpline (24/7)
+
+**6. Things to keep out of reach**
+
+- \_\_\_\_\_\_\_\_\_\_
+- \_\_\_\_\_\_\_\_\_\_
+
+When you're done, take a photo and set it as your phone's lock screen.
+Put a paper copy in your wallet.
+Tape one to the wall at home.
+In the crisis moment, you won't have to remember. It'll be in front of you.
+
+
+## References
+
+- Stanley, B., & Brown, G.K. (2012). Safety Planning Intervention: A Brief Intervention to Mitigate Suicide Risk. *Cognitive and Behavioral Practice*, 19(2), 256-264.
+- Karlsson, A., & Håkansson, A. (2018). Gambling disorder, increased mortality, suicidality, and associated comorbidity: A longitudinal nationwide register study. *Journal of Behavioral Addictions*, 7(4), 1091-1099.
+- Battersby, M., Tolchard, B., Scurrah, M., & Thomas, L. (2006). Suicide ideation and behaviour in people with pathological gambling attending a treatment service. *International Journal of Mental Health and Addiction*, 4(3), 233-246.
+- Wong, P.W.C., Cheung, D.Y.T., Conner, K.R., Conwell, Y., & Yip, P.S.F. (2010). Gambling and completed suicide in Hong Kong: a review of coroner court files. *The Primary Care Companion to the Journal of Clinical Psychiatry*, 12(6), PCC.09m00932.
+- Newman, S.C., & Thompson, A.H. (2003). A population-based study of the association between pathological gambling and attempted suicide. *Suicide and Life-Threatening Behavior*, 33(1), 80-87.
+- World Health Organization (2014). *Preventing Suicide: A Global Imperative*. WHO Press.
+- Mann, J.J., Apter, A., Bertolote, J., et al. (2005). Suicide prevention strategies: a systematic review. *JAMA*, 294(16), 2064-2074.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/shame-vs-guilt.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/shame-vs-guilt.md
@@ -1,0 +1,207 @@
+---
+category: "gambling"
+part: "D"
+chapter: 20
+title: "Separating Shame from Guilt"
+required: false
+excerpt: "The family meeting ended. My wife's parents had been there. My own parents had been there too. My debt, what I'd hidden from my wife, money meant for our kids' college that had gone to the casino. All of it, laid out in front of everyone."
+updatedAt: "2026-04-22"
+---
+The family meeting ended.
+My wife's parents had been there.
+My own parents had been there too.
+My debt, what I'd hidden from my wife, money meant for our kids' college that had gone to the casino.
+All of it, laid out in front of everyone.
+
+"You're done as a human being," my father said.
+I didn't push back. I thought he was right.
+
+Walking out of the house, I stopped at a vending machine.
+I couldn't move.
+I couldn't look at anyone in my family.
+"The world's better off without me" played on repeat in my head.
+
+Looking back, that moment was the most dangerous of all.
+Not because I was yelled at.
+Because I had agreed that I was "done."
+
+---
+
+## Shame and guilt aren't the same
+
+"Shame" and "guilt" feel similar, but psychological research draws a clear line between them.
+Short version:
+
+- **Guilt**: "I did a bad thing" (evaluation of an action)
+- **Shame**: "I am a bad person" (evaluation of the self)
+
+Guilt is the feeling that a specific thing you did was wrong.
+Shame is the feeling that who you are, as a person, is wrong.
+
+They look similar. Their effects are opposite.
+Guilt motivates behavior change. Shame paralyzes.
+
+---
+
+## How shame keeps addiction running
+
+Shame has a feedback loop that reinforces addiction.
+
+1. You gamble
+2. You feel "I'm a bad person" (shame)
+3. Living with that attack on yourself is unbearable
+4. You gamble to escape the unbearable feeling
+5. Back to step 1
+
+Shame is self-attack. Constant attack hurts.
+It hurts, so you want to escape it.
+The nearest way out is the addictive behavior.
+
+So shame itself becomes a relapse trigger.
+The more shame you feel after quitting, the more likely you are to go back.
+People who've stopped often feel shame more intensely, and that shame can pull them back.
+
+Research shows that people in recovery with higher shame levels have lower treatment response and higher relapse rates.
+
+---
+
+## Shame in addiction more broadly
+
+Cultural narratives about gambling addiction often still treat it as a moral failure: "weak character," "personal responsibility," "should have known better."
+When that narrative becomes your internal voice, you end up carrying shame twice over.
+
+- Shame about "being an addict"
+- Shame about "admitting you're an addict"
+
+That double layer is one of the biggest walls in recovery.
+
+Research on barriers to treatment consistently cites shame as a central reason people don't seek help.
+
+- "I can't let my family know"
+- "I can't tell a professional about this"
+- "I've failed as an adult"
+- "Only unstable people go to psychiatrists"
+
+These stop people from reaching care. And inside the isolation, addiction deepens.
+
+---
+
+## Guilt you can actually use
+
+While shame reinforces addiction, guilt is a usable feeling.
+
+- "I hurt my family by gambling" → guilt
+- "I'm beyond help as a person who gambled" → shame
+
+Guilt points at a specific behavior: "that was wrong."
+That makes it a motivator for change.
+It leads to constructive action: "I won't do it again," "I'll make amends," "I'll get help," "I'll handle the debt."
+
+Guilt can tip into shame when it scales up.
+The moment "that was wrong" becomes "I'm wrong," fuel becomes poison.
+
+Moderate guilt is fuel. Excessive guilt is poison.
+Knowing where that line is matters.
+
+---
+
+## Specific steps to move away from shame
+
+### Separate "I" from "what I did"
+
+Practice, in your head, splitting "self" from "action."
+
+- No: "I am a gambler"
+- Yes: "I gambled"
+
+One word difference, but it's a different process in the brain.
+"I am" evaluates the self.
+"I did" evaluates an action.
+
+Do this in a journal. Do it in your head.
+It feels awkward at first. It works with practice.
+
+### Speak shame out loud
+
+Shame grows in secret.
+Held alone, it gets bigger.
+
+Tell someone, and it gets smaller.
+Research on shame shows this too.
+- Peers from GA (Gamblers Anonymous)
+- A trusted family member or friend
+- A clinician or counselor
+- A support group
+
+"This is embarrassing to say" as a preface is enough.
+The moment it's heard, the shape of the shame changes.
+
+### Focus on fixing the behavior
+
+Redirect the energy from "I'm a bad person" into "here's what I do next."
+Moving to specific actions cuts off shame's oxygen.
+
+Examples:
+- "I hurt my family" → "tomorrow, I'll have one sentence ready to say to them"
+- "I'm in debt" → "next week, I'll call a non-profit credit counselor"
+- "I can't stop" → "I'll close one path to money today"
+
+Abstract self-criticism doesn't move recovery. Specific next steps do.
+
+### Self-compassion
+
+There's a practice called "self-compassion."
+Instead of attacking yourself, speak to yourself the way you'd speak to a friend.
+
+Ask yourself:
+**"If a friend were in this situation, what would I say to them?"**
+
+You wouldn't say "you're done."
+You'd say "that's really hard," "a lot had to go wrong to get here," "what do you want to do next."
+
+Say those things to yourself.
+It feels weird at first. With practice, shame thins out.
+
+---
+
+## Don't spend time on shame
+
+Spending time on shame wastes energy you need for recovery.
+The longer you're self-attacking, the slower recovery moves.
+The more you skip the self-attack and act, the faster it moves.
+
+This isn't about "forgiving yourself" or "letting yourself off the hook."
+**It's about where you're putting your energy.**
+
+Spend an hour on shame, and that's an hour not spent on "tomorrow's cutoffs," "what to say to your family," "finding care."
+Attacking yourself doesn't change anything. Action does.
+
+---
+
+## "The world's better off without me"
+
+The end of the opening scene was "the world's better off without me."
+That thought shows up when shame hits its ceiling.
+It's a well-known trigger for suicidal thinking in addiction.
+
+If you're here, activate the safety plan from [Chapter 8](/en/learn/quit-gambling-today/safety-plan/).
+No hesitation. Call a crisis line.
+
+> **Crisis resources**
+> The Suicide & Crisis Lifeline (24/7)
+> Crisis Text Line (text-based, 24/7)
+> Emergency services, for immediate danger
+
+Shame is something you feel. **It's not something you act on.**
+If it shows up, let it show up. Don't translate it into action.
+If you're not sure, tell someone.
+
+
+## References
+
+- Brown, B. (2012). *Daring Greatly: How the Courage to Be Vulnerable Transforms the Way We Live, Love, Parent, and Lead*. Gotham Books.
+- Brown, B. (2010). *The Gifts of Imperfection*. Hazelden Publishing.
+- Tangney, J.P., Stuewig, J., & Mashek, D.J. (2007). Moral emotions and moral behavior. *Annual Review of Psychology*, 58, 345-372.
+- Dearing, R.L., Stuewig, J., & Tangney, J.P. (2005). On the importance of distinguishing shame from guilt: Relations to problematic alcohol and drug use. *Addictive Behaviors*, 30(7), 1392-1404.
+- Neff, K.D. (2003). Self-compassion: An alternative conceptualization of a healthy attitude toward oneself. *Self and Identity*, 2(2), 85-101.
+- Yi, S., & Kanetkar, V. (2010). Coping with guilt and shame after gambling loss. *Journal of Gambling Studies*, 27(3), 371-387.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/thirty-day-plan.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/thirty-day-plan.md
@@ -1,0 +1,327 @@
+---
+category: "gambling"
+part: "E"
+chapter: 26
+title: "A 30-Day Recovery Plan"
+required: false
+excerpt: "Sunday morning. I woke up without an alarm. 9:30. Three months ago, I would have been waiting outside the casino already. Now I'm making coffee."
+updatedAt: "2026-04-22"
+---
+Sunday morning.
+I woke up without an alarm. 9:30.
+
+Three months ago, I would have been waiting for the casino to open already.
+Now I'm making coffee.
+
+The debt's still there. The relationship with my wife is still awkward.
+But I slept last night. I got out of bed.
+That's different from three months ago.
+
+---
+
+This is the last chapter.
+Grab a pen and a notebook.
+In this chapter, you write the 30-day plan in your own words.
+
+It doesn't have to be perfect. Write what you can. Skip what you can't.
+
+---
+
+## Why 30 days
+
+Recovery doesn't finish in 30 days.
+Addiction recovery is a months- and years-long process.
+
+Still, 30 days is useful as a unit.
+
+### The first stretch of brain change
+
+As [Chapter 4](/en/learn/quit-gambling-today/brain-recovers/) covered, the first 30 days after stopping are when the brain is most unstable.
+Getting through these 30 makes the next 30 a little easier.
+Thirty days is a reasonable marker for the first brain changes.
+
+### A plannable length
+
+A year is too long to plan.
+A week is too short to see change.
+Thirty days (about four weeks) is a good length to plan and to actually see shifts in.
+
+### "First 30" can be drawn again
+
+When 30 days are done, start a new 30.
+If you relapse inside the 30, a new 30 starts the next day.
+"First 30 days" is a unit you can redraw however many times you need.
+
+---
+
+## Week 1: Physical cutoffs
+
+The first week is about physical cutoffs.
+Don't try to master something new this week.
+Just make it so gambling isn't possible.
+
+### What to do (in priority order)
+
+1. **Cut off access to money** ([Chapter 6](/en/learn/quit-gambling-today/money-access/))
+   - At least one thing done today
+   - As many as possible inside one week
+2. **Set up emergency contacts** ([Chapter 8](/en/learn/quit-gambling-today/safety-plan/))
+   - Save crisis resources on your phone
+   - Write out a safety plan on one page
+3. **Build a personal map** ([Chapter 24](/en/learn/quit-gambling-today/personal-map/))
+   - Put all five sections on one sheet
+4. **"Report" to your family** ([Chapter 19](/en/learn/quit-gambling-today/family/))
+   - Short, three lines
+5. **Pick a morning routine** ([Chapter 7](/en/learn/quit-gambling-today/payday-survival/))
+   - One thing, under five minutes
+
+### Week 1 checklist
+
+<div class="worksheet">
+
+□ 1. Set credit card cash advance limits to $0
+□ 2. Destroy or hand over cards used for gambling
+□ 3. Lower daily ATM withdrawal limit
+□ 4. Uninstall all gambling apps and delete bookmarks
+□ 5. Save crisis resources on phone
+□ 6. Write a one-page safety plan
+□ 7. Draw a one-page personal map
+□ 8. "Report" to family
+□ 9. Pick a morning routine
+□ 10. Once a day, name one feeling ([Chapter 22](/en/learn/quit-gambling-today/naming-emotions/))
+
+</div>
+
+You don't have to do all ten.
+Check off what you did. Look at the count.
+Even one check is evidence of movement.
+
+---
+
+## Week 2: Know your triggers
+
+The second week is about knowing your triggers.
+Skills come after you know the triggers.
+
+### What to do
+
+1. **Make HALT a habit** ([Chapter 11](/en/learn/quit-gambling-today/halt/))
+   - When a craving hits, check the four
+2. **Draw your trigger map** ([Chapter 13](/en/learn/quit-gambling-today/trigger-map/))
+   - Place, people, time, emotion: fill in your triggers
+3. **Observe cognitive distortions** ([Chapter 12](/en/learn/quit-gambling-today/cognitive-distortions/))
+   - Practice catching "this is a distortion" in your own head
+4. **Make three if-then plans** ([Chapter 14](/en/learn/quit-gambling-today/if-then-plan/))
+   - Three "if X, then Y" pairs
+5. **Build an alternative activity list** ([Chapter 11](/en/learn/quit-gambling-today/halt/))
+   - Five alternatives to gambling
+
+### Week 2 checklist
+
+<div class="worksheet">
+
+□ 1. Run the HALT check three times a day
+□ 2. Draw your trigger map
+□ 3. Write down five of your own "distortion lines"
+□ 4. Make three if-then plans
+□ 5. Make a list of five alternative activities
+□ 6. Talk to one person once this week ([Chapter 10](/en/learn/quit-gambling-today/asking-for-help/))
+□ 7. Move your body for 10 minutes a day
+□ 8. Once a day, name one feeling
+
+</div>
+
+---
+
+## Week 3: Face reality
+
+The third week is about facing the realities you've been avoiding.
+It has a high chance of being the hardest week.
+Set up your safety plan and your contact list before starting.
+
+### What to do
+
+1. **Get your total debt** ([Chapter 17](/en/learn/quit-gambling-today/debt-overview/))
+   - Put every creditor's balance in one table
+2. **Research legal options** ([Chapter 18](/en/learn/quit-gambling-today/legal-options/))
+   - Call a non-profit credit counselor or a legal aid clinic
+3. **Mental health self-check** ([Chapter 15](/en/learn/quit-gambling-today/mental-health/))
+   - Screen for depression, anxiety, ADHD
+4. **Write out your denial lines** ([Chapter 16](/en/learn/quit-gambling-today/denial/))
+   - Find your denial patterns
+5. **One real conversation with family** ([Chapter 19](/en/learn/quit-gambling-today/family/))
+   - In "report" form
+
+### Week 3 checklist
+
+<div class="worksheet">
+
+□ 1. Get your total debt
+□ 2. Call a non-profit credit counselor (or save the number, at minimum)
+□ 3. Do a mental health self-check
+□ 4. Book a psychiatric appointment if needed
+□ 5. Write your denial lines
+□ 6. Have a "report" conversation with family
+□ 7. Once a day, name one feeling
+□ 8. Keep the [safety plan](/en/learn/quit-gambling-today/safety-plan/) visible every day
+
+</div>
+
+Week 3 often hits hardest.
+If it gets painful, activate the safety plan.
+Don't carry it alone.
+Call the person you said you'd call.
+
+---
+
+## Week 4: Start rebuilding
+
+The fourth week is for organizing what you've done and preparing for the next 30.
+
+### What to do
+
+1. **Inventory your recovery capital** ([Chapter 23](/en/learn/quit-gambling-today/recovery-capital/))
+   - Write down what you have in each of the four categories
+2. **Revise your personal map** ([Chapter 24](/en/learn/quit-gambling-today/personal-map/))
+   - Add new contacts to the map from Week 1
+3. **Post-relapse action list** ([Chapter 25](/en/learn/quit-gambling-today/relapse-not-failure/))
+   - Seven actions for the day after a relapse, on one page
+4. **Keep the morning routine** ([Chapter 7](/en/learn/quit-gambling-today/payday-survival/))
+5. **Write a letter to yourself 30 days from now** (next section)
+
+### Week 4 checklist
+
+<div class="worksheet">
+
+□ 1. Inventory your recovery capital
+□ 2. Revise your personal map with new contacts
+□ 3. Write a post-relapse action list
+□ 4. Keep doing the morning routine every day
+□ 5. Write a letter to your future self 30 days out
+□ 6. Plan the next 30 days
+□ 7. Once a day, name one feeling
+□ 8. Pick one chapter you want to reread
+
+</div>
+
+---
+
+## A letter to yourself 30 days from now
+
+Grab the pen and notebook.
+This is the most important exercise in the book.
+
+### What to write
+
+Write to the version of yourself 30 days from now.
+
+1. **What is the "me" of 30 days ago (now) like**
+   - State of mind
+   - State of body
+   - Debt picture
+   - Family relationships
+   - Where gambling is
+
+2. **What did I learn or try in 30 days**
+   - What worked
+   - What didn't
+   - What I noticed
+
+3. **What do I want to tell my 30-day-later self**
+   - What to keep doing
+   - What to watch out for
+   - A sentence from the present me to the future me
+
+### An example template
+
+<div class="worksheet">
+
+To my future self,
+
+Right now I'm writing this at ___ (place), at ___ (time).
+I've been struggling with gambling, and I just finished this book.
+
+Over these 30 days, I did ___.
+What worked was ___.
+What didn't work was ___.
+What I noticed was ___.
+
+To the you 30 days from now:
+Keep doing ___.
+Watch out for ___.
+Don't forget ___.
+
+___ (my name)
+___ / ___ / ___
+
+</div>
+
+### Open it 30 days later
+
+Put the letter in an envelope, seal it.
+Write "open in 30 days" on the outside. Put it somewhere you'll see.
+Mark "open the letter" on your calendar.
+
+Thirty days later, open it.
+Your future self will read the words of your present self.
+It lands harder than you expect.
+
+---
+
+## "One thing a day" is the rule
+
+Looking at the 30-day checklist, it can feel like too much.
+That's a normal reaction.
+
+**Do one thing a day. That's all.**
+
+Trying to do multiple things perfectly in a day doesn't sustain.
+One a day is enough.
+If, at the end of the day, you can say "I did ___ today," that's enough.
+
+30 days × 1 = 30 things.
+30 things done is a lot of forward motion.
+
+### "Nothing" days are okay too
+
+Some days in the 30, you won't do anything.
+Days you're in bed, days you fight with your family, days you relapse, days of despair, days with no energy.
+These are normal.
+
+Don't punish yourself on nothing days.
+Don't punish. Do one thing tomorrow instead.
+The 30 doesn't have to be consecutive. 30 "doing" days, even interrupted, is still 30.
+
+---
+
+## To the person who read this far
+
+Thank you for reading this far.
+
+You don't have to understand everything.
+Getting here means you're already on the starting line.
+
+This book isn't a one-read book.
+Thirty days from now, three months from now, a year from now, rereading it can land differently.
+If a chapter catches your eye, come back whenever.
+
+What we couldn't cover (long-term recovery, detailed cognitive behavioral therapy, trauma treatment, medication), leave to clinicians, support groups, and specialists.
+This book is a map that opens a door.
+
+One last thing, which I already wrote in [Chapter 5](/en/learn/quit-gambling-today/recovery-exists/).
+
+Whether you recover is not something anyone can predict right now.
+But the people who kept trying are the ones who got there.
+
+Relapse as many times as you need to. Start again.
+Only the people who "start again" meet the turning point someday.
+
+
+## References
+
+- DiClemente, C.C., & Velasquez, M.M. (2002). Motivational interviewing and the stages of change. In W.R. Miller & S. Rollnick (Eds.), *Motivational Interviewing: Preparing People for Change* (2nd ed., pp. 201-216). Guilford Press.
+- Prochaska, J.O., DiClemente, C.C., & Norcross, J.C. (1992). In search of how people change: Applications to addictive behaviors. *American Psychologist*, 47(9), 1102-1114.
+- Marlatt, G.A., & Donovan, D.M. (Eds.) (2005). *Relapse Prevention: Maintenance Strategies in the Treatment of Addictive Behaviors* (2nd ed.). Guilford Press.
+- Miller, W.R., & Rollnick, S. (2012). *Motivational Interviewing: Helping People Change* (3rd ed.). Guilford Press.
+- White, W.L. (2007). Addiction recovery: Its definition and conceptual boundaries. *Journal of Substance Abuse Treatment*, 33(3), 229-241.
+- Vaillant, G.E. (1995). *The Natural History of Alcoholism Revisited*. Harvard University Press.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/treatment-options.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/treatment-options.md
@@ -1,0 +1,322 @@
+---
+category: "gambling"
+part: "D"
+chapter: 21
+title: "Where to Start with Treatment"
+required: false
+excerpt: "Lunch break. A corner table at the coffee shop near the office. I typed 'gambling addiction treatment' into my phone."
+updatedAt: "2026-04-22"
+---
+<div class="note">
+
+This chapter is general information, not medical advice. Specific treatment plans are decided with a clinician. Resource availability varies by state and changes over time.
+
+</div>
+
+Lunch break.
+A corner table at the coffee shop near the office.
+I typed "gambling addiction treatment" into my phone.
+
+A list came up: state problem-gambling programs, outpatient clinics, specialty addiction centers.
+I couldn't tell the difference between them.
+
+I stared at the screen for ten minutes before calling.
+Then I read a post from a recovery community, and I ended up not calling that day.
+Back at home that night, I decided: "I'll call tomorrow, on my lunch break."
+
+The next day, I actually called.
+The person who picked up sounded like a regular human.
+"This is my first time calling," I said.
+"Thank you for calling us," she said back.
+We booked an intake appointment before the call ended.
+
+---
+
+## Treatment isn't a single option
+
+There are multiple options for treating and supporting gambling addiction.
+You don't have to pick one. Most people combine.
+
+Main options:
+
+- **GA (Gamblers Anonymous)**: peer-led support groups
+- **Outpatient psychiatry or primary care**: general clinics
+- **Problem-gambling treatment programs**: specialty providers
+- **Inpatient / residential treatment**: intensive care
+- **Sober living and recovery housing**: medium- to long-term living support
+- **State problem-gambling helplines and clinics**: public resources
+- **Family support groups (Gam-Anon, etc.)**: for family members
+- **Apps and digital tools**: self-tracking and community
+
+Each has a different role. Going through them one by one.
+
+---
+
+## GA (Gamblers Anonymous)
+
+GA is a peer-led mutual support group for people with gambling addiction.
+It started in 1957 in Los Angeles and now has meetings worldwide.
+
+- Format: peer meetings (usually weekly or more often)
+- Thousands of groups across the U.S.
+- Free
+- No appointment needed, come and go as you need
+- No face, no real name (first name only is typical)
+- Starts with "Hi, I'm ___, and I have a gambling problem"
+- Uses a 12-step recovery framework
+
+Pros:
+- Connection with people who get it
+- Hearing the experience of people who've been where you are
+- Easy to sustain
+- Free
+- A lower-barrier entry than a psychiatrist's office for many people
+
+Cons:
+- 12 steps have religious overtones that some find uncomfortable
+- Group culture varies from meeting to meeting
+- Don't decide "GA isn't for me" after one meeting. Try several
+
+Find your nearest meeting through Gamblers Anonymous.
+
+---
+
+## Outpatient psychiatry or primary care
+
+Your primary care doctor or a neighborhood psychiatrist can also be a starting point.
+
+- Accessible (often close to where you live)
+- Usually covered by insurance
+- Typically requires an appointment
+- Copays and deductibles vary by plan
+
+Pros:
+- Easy to access
+- Can often fit around work
+- Can prescribe medication if useful
+
+Cons:
+- Not every clinician is trained in addiction
+- Without gambling-specific experience, treatment depth can be limited
+
+It's reasonable to call ahead and ask, "do you treat gambling addiction?" If they don't, ask for a referral to someone who does.
+
+---
+
+## Problem-gambling treatment programs
+
+Specialty providers focus on gambling disorder and related issues.
+
+Where to find them:
+
+- **State problem gambling councils**: most states have one, often affiliated with the National Council on Problem Gambling (NCPG)
+- **The National Problem Gambling Helpline**: a 24/7 line that can refer you to providers in your state
+- **Academic medical centers**: many university hospitals have specialty gambling programs
+- **Community mental health centers**: some have certified gambling counselors
+
+Pros:
+- Higher specialty depth
+- Programs tailored to gambling (group therapy, cognitive behavioral therapy, family work)
+- Contact with other patients in similar situations
+- Covered by insurance or, in many states, subsidized for state residents
+
+Cons:
+- Fewer of them (can be far away depending on where you live)
+- Intake wait times can be weeks to months
+- Travel time
+
+To find state-funded gambling counseling, the National Problem Gambling Helpline is the single fastest starting point.
+
+---
+
+## Inpatient and residential treatment
+
+Inpatient addiction treatment runs in a few patterns.
+
+- Short-term inpatient (weeks)
+- Medium-term residential (weeks to months)
+- Dual-diagnosis programs treating gambling alongside mental health conditions
+
+Pros:
+- Complete separation from the environment (no phones, no casinos, no apps)
+- Intensive treatment and evaluation
+- Co-occurring conditions (depression, anxiety) evaluated at the same time
+- Discharge planning for aftercare
+
+Cons:
+- Time off work required
+- Cost is significant (even with insurance, out-of-pocket can be substantial)
+- Psychological barrier to "going inpatient"
+- Limited number of facilities that treat gambling specifically
+
+Inpatient is considered when outpatient isn't enough, when comorbidities are severe, when suicide risk is high, or when the home environment is unsafe.
+
+---
+
+## Sober living and recovery housing
+
+Non-medical options also exist: recovery housing, Oxford Houses, and sober-living homes.
+Originally developed for substance addictions, many accept gambling recovery residents.
+
+- Medium- to long-term living support (months to years)
+- Structured daily programs plus shared living
+- Living alongside others in recovery
+
+Pros:
+- Full environmental change
+- Peer support around the clock
+- Isolation gets harder to maintain
+
+Cons:
+- Work alongside housing can be hard
+- Costs vary, though some are income-based or state-subsidized
+- Shared living isn't for everyone
+
+For people who feel "I can't rebuild my life on my own," this is a strong option.
+
+---
+
+## State and public resources
+
+"I don't know where to start" often has its fastest answer here.
+
+- **The National Problem Gambling Helpline** (24/7, operated by NCPG): a single line that connects to state resources
+- **State problem gambling councils**: free referrals and often free counseling
+- **Community mental health centers**: in most counties
+- **The United Way's community-services line**: can route calls to mental health and addiction resources
+
+Pros:
+- Free
+- Start on the phone (no face-to-face required)
+- They refer to clinical providers
+- Confidential
+
+A lot of people worry "what will they ask me?" Nothing hard.
+You can use a nickname if you want.
+Just saying which state you're in is enough for them to give you local options.
+
+Opening line:
+
+> "I'd like to talk about gambling. I don't really know where to start."
+
+They'll take the conversation from there.
+
+---
+
+## Family groups (Gam-Anon)
+
+There are support groups for family members too.
+The main one is Gam-Anon, a counterpart to GA for families.
+
+- For partners, parents, kids, and others close to someone with gambling addiction
+- Families share experience with other families
+- Runs independently of the gambler (families can attend without the gambler)
+
+This isn't for you, it's for your family. But when family members connect to support, the situation at home often shifts.
+This book is for you, but Gam-Anon is worth knowing about and mentioning to your family.
+
+---
+
+## Apps and digital tools
+
+Smartphone apps supporting addiction recovery have been growing in recent years.
+They don't replace a clinician, but they can be useful as a first step before treatment, or in parallel with treatment.
+
+### QuitMate
+
+QuitMate is a smartphone app for recovery across multiple addictions, including gambling.
+
+Main features:
+- Tracking your abstinence (streak management)
+- A community of people in recovery (posts, comments, likes, following)
+- Recording and reviewing relapses
+- Reading and writing recovery stories
+- Multiple categories (gambling, alcohol, nicotine, porn, etc.)
+
+Notable:
+- Free to start
+- No face, no real name (nicknames)
+- Always available
+- Around 8,000 users (as of 2026)
+
+Pros:
+- Low-friction first step before calling a clinician
+- Usable in the middle of the night
+- Read the stories of people doing the same thing
+- Visualize your streak and relapses
+
+Cons:
+- An app can't deliver clinical evaluation or treatment
+- Severe cases require clinical care alongside it
+- Apps alone don't "cure" addiction
+
+### How apps and clinicians fit together
+
+Apps don't replace clinical care.
+But they work as either a bridge before clinical care or a daily complement to it.
+
+Example combinations:
+
+- Use the app for self-tracking for a few weeks while you figure out your state
+- Visit one GA meeting in parallel
+- If that's not enough, book an intake at a specialty provider
+- Once you're in treatment, keep using the app for the daily log
+
+Combining app, peer groups, and clinical care covers each channel's weak points.
+Having more than one entry point makes recovery more stable than relying on one.
+
+---
+
+## Where to start
+
+A rough guide when the options feel overwhelming:
+
+| Situation | First step |
+|---|---|
+| Want to start with self-tracking | Smartphone app (QuitMate, etc.) |
+| Don't know where to start at all | State problem-gambling helpline, or the Suicide & Crisis Lifeline if you're in mental-health crisis |
+| Want to know local options | State problem gambling council, or a general social-services line |
+| Want specialized clinical care | State-funded gambling counselor, or NCPG helpline for referral |
+| Want peer support | A GA meeting |
+| Need to physically leave the environment | Inpatient or residential program |
+| Can't talk to your family | Point them to Gam-Anon |
+| Debt is the main issue | Non-profit credit counselor, bankruptcy attorney (see [Chapter 18](/en/learn/quit-gambling-today/legal-options/)) |
+
+You don't need to evaluate all of these at once.
+Start with one. If it doesn't fit, try the next.
+Combining (a specialty provider + GA, inpatient + GA after discharge, helpline + primary care) is normal.
+
+---
+
+## Lowering the bar for "getting treatment"
+
+"Getting treatment" carries a lot of baggage.
+Psychiatric hospitals, long stays, specialized interventions.
+That image makes the bar feel high.
+
+The real first visit is ordinary.
+
+1. You call
+2. You make an appointment
+3. You show up and fill out paperwork
+4. You talk to a clinician
+5. You schedule the next visit if needed
+
+That's it. Not much different from a trip to urgent care for a cough.
+The first session runs 30 to 60 minutes.
+You don't have to be grave. Just tell them honestly what's been happening.
+
+Clinicians and staff in addiction care see this every day.
+Nothing you say will shock them. Everything you say will be received.
+"If I say this, will they judge me?" is almost never warranted.
+
+
+## References
+
+- National Council on Problem Gambling. https://www.ncpgambling.org/
+- National Problem Gambling Helpline (24/7, confidential). Operated by NCPG.
+- Gamblers Anonymous. http://www.gamblersanonymous.org/
+- Gam-Anon International Service Office. https://www.gam-anon.org/
+- SAMHSA (Substance Abuse and Mental Health Services Administration). https://www.samhsa.gov/
+- Petry, N.M. (2005). *Pathological Gambling: Etiology, Comorbidity, and Treatment*. American Psychological Association.
+- Cowlishaw, S., Merkouris, S., Dowling, N., Anderson, C., Jackson, A., & Thomas, S. (2012). Psychological therapies for pathological and problem gambling. *Cochrane Database of Systematic Reviews*, 11, CD008937.

--- a/apps/lp/src/content/learn/en/quit-gambling-today/trigger-map.md
+++ b/apps/lp/src/content/learn/en/quit-gambling-today/trigger-map.md
@@ -1,0 +1,309 @@
+---
+category: "gambling"
+part: "C"
+chapter: 13
+title: "Drawing Your Trigger Map"
+required: false
+excerpt: "Saturday, 3 p.m. On the couch, watching TV. Bored."
+updatedAt: "2026-04-22"
+---
+Saturday, 3 p.m.
+On the couch, watching TV.
+Bored.
+
+Without thinking, I picked up my phone.
+Before I noticed, I was about to open the sports betting app.
+
+Just bored. That was it. That was enough.
+"Bored" was the trigger, and I didn't know it was the trigger.
+You can't defend against a trigger you can't see.
+
+---
+
+## What a trigger is
+
+A trigger is a cue that sets off a craving or a behavior.
+The word comes from the trigger of a gun, and it's used widely in addiction.
+
+A trigger starts before you consciously "want to do it."
+Your body reacts, or the "justification lines" start running.
+It's the brain automatically releasing dopamine that we've been covering since earlier chapters.
+
+Triggers fall into four broad categories.
+
+1. Place
+2. People
+3. Time
+4. Emotion
+
+Going through each one. Then you'll draw your own trigger map.
+
+---
+
+## Place triggers
+
+Place triggers are the most obvious.
+Your brain has linked "that location" with "gambling."
+Being there fires a reaction before you've done anything.
+
+Examples:
+
+- A casino or sportsbook
+- A sports bar with betting screens
+- A particular intersection on your commute (there's a gas station with scratch-offs, or a casino on the corner)
+- An ATM
+- Your bank on payday
+- The location on your phone where the betting apps used to be
+- The couch where you used to bet online
+- A favorite diner or convenience store (places you've pulled out cash)
+
+It's not just physical places. "Locations inside your screen" count too.
+A specific home screen layout. A specific browser tab. A specific YouTube channel.
+
+---
+
+## People triggers
+
+People triggers are easy to miss.
+Being around certain people, by itself, can trigger the pull toward gambling.
+
+Examples:
+
+- Friends you used to gamble with
+- A coworker who says "let's hit the sportsbook"
+- Family members who bring up gambling
+- People who've lent you money in the past
+- People who say "well, a little won't hurt"
+- People who mean well but let you off the hook
+
+People triggers are often not "bad people."
+Often it's "good people" or "people you care about" that trigger the strongest pull.
+Close relationships are harder to decline, and that's exactly what makes them triggers.
+
+Handling people triggers is hard.
+You don't have to cut contact. You do have to engineer situations where declining a specific outing is structurally possible.
+
+---
+
+## Time triggers
+
+Time is a powerful trigger.
+Your brain has linked "certain times" with "gambling."
+
+Examples:
+
+- Payday (morning and evening)
+- End of the month, start of the month
+- Friday night
+- Saturday morning
+- Sunday afternoon (the NFL window)
+- Holidays, bonus season
+- The day a big work project wrapped
+- Empty time on days off
+- After your family's gone to bed
+- Business trips, time away from family
+
+Time triggers you can put on a calendar.
+Being on the calendar means you can plan around them.
+You can block out the risky hours in advance.
+
+---
+
+## Emotion triggers
+
+These are the hardest to see.
+Certain emotions pull you toward gambling.
+
+Examples:
+
+- Boredom
+- Loneliness
+- Anger (work, family, the world)
+- Anxiety (money, work, the future)
+- Sadness (failure, loss)
+- Accomplishment (even good days are risky)
+- Overconfidence ("today's my day" feeling)
+- Low mood
+- Numbness, emptiness
+
+In the opening scene, "boredom" was the trigger.
+The person didn't know boredom was a trigger.
+That's why they couldn't defend.
+
+Emotion triggers overlap with the HALT from [Chapter 11](/en/learn/quit-gambling-today/halt/).
+HALT is a focused basic set of four. Emotion triggers cover a wider range.
+
+---
+
+## Drawing your trigger map
+
+Use all four categories to build a personal trigger map.
+
+### Step 1: Recall the last three relapses
+
+Think back to the last three times you relapsed.
+For each, write down:
+
+<div class="worksheet">
+
+Relapse 1 (date: _____ )
+Place:
+People:
+Time:
+Emotion:
+
+Relapse 2 (date: _____ )
+Place:
+People:
+Time:
+Emotion:
+
+Relapse 3 (date: _____ )
+Place:
+People:
+Time:
+Emotion:
+
+</div>
+
+### Step 2: Find the overlap
+
+Line them up side by side. Overlap appears.
+Most people relapse on a specific combination, over and over.
+
+Example:
+- Place: always a casino
+- People: always alone
+- Time: always payday evening
+- Emotion: always anger or boredom
+
+That's your typical trigger pattern.
+
+### Step 3: Put it on the map
+
+On one sheet of paper, lay out the four categories. Under each, list your triggers.
+Mark shared ones in bold or in red.
+
+<div class="worksheet-grid">
+<div>
+
+[Place]
+- Local casino
+- Sportsbook downtown
+- Intersection on commute
+
+</div>
+<div>
+
+[People]
+- Former coworker A
+- The one friend who always suggests betting
+
+</div>
+<div>
+
+[Time]
+- Payday evening
+- Friday night
+- Afternoons off
+
+</div>
+<div>
+
+[Emotion]
+- Anger
+- Boredom
+- Loneliness
+
+</div>
+</div>
+
+Put the map somewhere you'll see it: kitchen wall, phone wallpaper, inside your wallet.
+
+### Step 4: Review monthly
+
+Triggers change over time.
+New ones appear, old ones fade.
+
+Every month, look at the map.
+If you had a relapse, add its triggers.
+Draw a line through ones that have stopped mattering.
+
+---
+
+## Using the map in daily life
+
+The map isn't just for making. It's for using.
+
+### Flag dangerous days in advance
+
+Open your calendar. Mark days where your triggers stack up.
+- Payday → mark
+- Friday night → mark
+- Day after a night out → mark
+- Before or after a business trip → mark
+
+On marked days, lock in a protective move in advance (spend it with family, go to the gym, etc.).
+
+### Notice a trigger when it fires
+
+The more familiar you are with the map, the easier it is to catch "oh, that trigger is firing."
+Once you catch it, connect to [Chapter 14 (if-then plans)](/en/learn/quit-gambling-today/if-then-plan/) or [Chapter 9 (craving skills)](/en/learn/quit-gambling-today/craving-basics/).
+
+### Reduce triggers physically
+
+If "place" is a big category for you: change commute routes, fully delete the apps, restructure your physical environment.
+If "people" is big: prepare specific words for declining the invites.
+If "time" is big: fill those hours with something else.
+If "emotion" is big: set a default response for each named emotion.
+
+### Build a list of alternative activities
+
+Making decisions in the crisis is hard. On calm days, write a list of things you can do instead of gambling.
+
+<div class="worksheet-grid">
+<div>
+
+[At home]
+- ___________
+- ___________
+- ___________
+
+</div>
+<div>
+
+[Outside]
+- ___________
+- ___________
+- ___________
+
+</div>
+<div>
+
+[With someone]
+- ___________
+- ___________
+- ___________
+
+</div>
+<div>
+
+[No money required]
+- ___________
+- ___________
+- ___________
+
+</div>
+</div>
+
+At least three in each. Mark three of them with a star: "I can start this within 5 minutes, right now."
+
+
+## References
+
+- Marlatt, G.A., & Donovan, D.M. (Eds.) (2005). *Relapse Prevention: Maintenance Strategies in the Treatment of Addictive Behaviors* (2nd ed.). Guilford Press.
+- Witkiewitz, K., & Marlatt, G.A. (2004). Relapse prevention for alcohol and drug problems: That was Zen, this is Tao. *American Psychologist*, 59(4), 224-235.
+- Hodgins, D.C., & el-Guebaly, N. (2004). Retrospective and prospective reports of precipitants to relapse in pathological gambling. *Journal of Consulting and Clinical Psychology*, 72(1), 72-80.
+- Echeburúa, E., Fernández-Montalvo, J., & Báez, C. (2001). Predictors of therapeutic failure in slot-machine pathological gamblers following behavioural treatment. *Behavioural and Cognitive Psychotherapy*, 29(3), 379-383.
+- Sharpe, L. (2002). A reformulated cognitive-behavioral model of problem gambling: A biopsychosocial perspective. *Clinical Psychology Review*, 22(1), 1-25.
+- Brown, R.I.F. (1987). Pathological gambling and associated patterns of crime: Comparisons with alcohol and other drug addictions. *Journal of Gambling Behavior*, 3(2), 98-114.


### PR DESCRIPTION
## Summary
- 「あと1万が止まらない」（全26章＋本書について）を自然な米国英語に翻訳し `apps/lp/src/content/learn/en/quit-gambling-today/` 以下に配置
- 日本特有の要素を米国文脈に置換: パチンコ→slots/sportsbook、任意整理/個人再生/自己破産→debt settlement/Chapter 13/Chapter 7、法テラス→NFCC・legal aid、JICC/CIC貸付自粛→credit freeze(Equifax/Experian/TransUnion)、久里浜医療センター等→NCPG・GA・state councils、ギャマノン→Gam-Anon
- 電話番号はすべて削除しサービス名のみ記載（988 Suicide & Crisis Lifeline、Crisis Text Line、National Problem Gambling Helpline 等）
- 日本語リンク `/ja/` は全て `/en/` に変換、em-dashなし（プロジェクトルール準拠）
- ファクトチェック実施済み: 法律条文（11 U.S.C. § 523、Chapter 7 means test、信用情報保持期間）、団体名・URL、統計（NCPG 2.5M severe / 5-8M mild-moderate、PASPA 2018 Murphy v. NCAA）すべて現行と一致

## Test plan
- [x] `yarn build:lp` 成功（155 pages、英語版27章＋OG画像が生成）
- [x] 内部リンクが全て `/en/learn/quit-gambling-today/...` に解決
- [x] em-dash・電話番号・日本語文字の残存なし
- [x] 事実検証: 全資源案内（危機ライン、法律・金融制度、支援団体、統計）が2026年時点で正確
- [ ] プレビューで各章ページと OG 画像の見た目を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)