### PR TITLE
fix(lp): ロケールなしページが末尾スラッシュ付きURLで404になる問題を修正

### DIFF
--- a/apps/lp/public/_redirects
+++ b/apps/lp/public/_redirects
@@ -1,8 +1,13 @@
 # ロケールなしページ → /en/（デフォルトロケール）
+# 末尾スラッシュの有無どちらでも動くように両方列挙
 /contact /en/contact/ 301
+/contact/ /en/contact/ 301
 /privacy /en/privacy/ 301
+/privacy/ /en/privacy/ 301
 /terms /en/terms/ 301
+/terms/ /en/terms/ 301
 /apps /en/apps/ 301
+/apps/ /en/apps/ 301
 
 # カテゴリページ
 /alcohol/* /en/alcohol/:splat 301


### PR DESCRIPTION
## Summary
- `/privacy/`（末尾スラッシュ付き）が 404 になっていた
- 原因: `_redirects` に `/privacy`（スラッシュなし）のルールしかなく、Cloudflare Pages は末尾スラッシュ有無を厳密に区別するため `/privacy/` にマッチしていなかった
- 修正: `/contact`, `/privacy`, `/terms`, `/apps` について末尾スラッシュ版のルールも追加

## 症状の確認
| URL | 修正前 | 修正後想定 |
|:--|:-:|:-:|
| `/privacy` | 301 ✓ | 301 |
| `/privacy/` | **404** | 301 |
| `/contact/` | **404** | 301 |
| `/terms/` | **404** | 301 |
| `/apps/` | **404** | 301 |

`/alcohol/` 等のカテゴリページは `/alcohol/*` 側のスプラットがマッチするので既に動作していた（このPRでは変更なし）。

## Test plan
- [ ] デプロイ後、`curl -I https://about.quitmate.app/privacy/` が 301 で `/en/privacy/` に飛ぶ
- [ ] 同様に `/contact/`, `/terms/`, `/apps/` も 301
- [ ] 末尾スラッシュなしの `/privacy` 等もこれまで通り動く（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)