### PR TITLE
refactor(lp): /learn 本詳細ページから押せない装飾ハートアイコンを削除

### DIFF
--- a/apps/lp/src/pages/en/learn/[book]/index.astro
+++ b/apps/lp/src/pages/en/learn/[book]/index.astro
@@ -60,9 +60,6 @@ const firstChapterUrl = hasContent ? chapterUrl(locale, bookSlug, chapters[0]) :
       <div class="flex min-w-0 flex-1 flex-col">
         <h1 class="mb-2 text-2xl font-bold leading-tight text-gray-900 sm:text-3xl">{bookTitle}</h1>
         <div class="mb-5 flex items-center gap-3">
-          <div class="flex h-7 w-7 items-center justify-center rounded-full bg-primary-100">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 text-primary-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" /></svg>
-          </div>
           <span class="text-sm font-medium text-gray-700">QuitMate</span>
           <span class="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs text-gray-500">{categoryLabel}</span>
         </div>

--- a/apps/lp/src/pages/ja/learn/[book]/index.astro
+++ b/apps/lp/src/pages/ja/learn/[book]/index.astro
@@ -65,9 +65,6 @@ const firstChapterUrl = hasContent ? chapterUrl(locale, bookSlug, chapters[0]) :
           <p class="mb-3 text-sm text-gray-500">{bookSubtitle}</p>
         )}
         <div class="mb-5 flex items-center gap-3">
-          <div class="flex h-7 w-7 items-center justify-center rounded-full bg-primary-100">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 text-primary-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" /></svg>
-          </div>
           <span class="text-sm font-medium text-gray-700">QuitMate</span>
           <span class="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs text-gray-500">{categoryLabel}</span>
         </div>


### PR DESCRIPTION
## Summary

- `/learn` 本詳細ページ (`apps/lp/src/pages/{en,ja}/learn/[book]/index.astro`) に表示されていた、クリックできない装飾のハートアイコンを削除
- 機能しない UI はユーザーの誤認を招くため除去

## Test plan

- [ ] `yarn build:lp` が通ること
- [ ] `/ja/learn/[book]` と `/en/learn/[book]` でハートアイコンが表示されなくなっていること
- [ ] レイアウト崩れがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)