### PR TITLE
refactor(lp): BlogPostCard を共通コンポーネント化

### DIFF
--- a/apps/lp/src/components/sections/BlogPostCard.astro
+++ b/apps/lp/src/components/sections/BlogPostCard.astro
@@ -1,0 +1,62 @@
+---
+import type { Locale } from "@/i18n/config";
+import { extractFirstImage } from "@/utils/blog";
+import { getCategoryColor } from "@/utils/category";
+
+type Post = {
+  id: string;
+  body?: string;
+  data: {
+    title: string;
+    date: string;
+    excerpt: string;
+    category?: string;
+  };
+};
+
+type Props = {
+  post: Post;
+  locale: Locale;
+  filterable?: boolean;
+};
+
+const { post, locale, filterable = false } = Astro.props;
+const slug = post.id.replace(/\.md$/, "");
+const coverImage = extractFirstImage(post.body ?? "");
+---
+
+<a
+  href={`/${locale}/blog/${slug}/`}
+  class="group block"
+  data-blog-card={filterable ? "" : undefined}
+  data-category={filterable ? (post.data.category ?? "") : undefined}
+>
+  <article class="h-full overflow-hidden rounded-xl bg-white shadow-md transition-shadow hover:shadow-lg">
+    {coverImage && (
+      <div class="aspect-video w-full overflow-hidden">
+        <img
+          src={coverImage}
+          alt={post.data.title}
+          class="size-full object-cover transition-transform group-hover:scale-105"
+          loading="lazy"
+        />
+      </div>
+    )}
+    <div class="px-3 py-2 sm:px-4 sm:py-3">
+      <div class="flex items-center justify-between">
+        {post.data.category && (
+          <span class={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${getCategoryColor(post.data.category)}`}>
+            {post.data.category}
+          </span>
+        )}
+        <time class="text-xs text-gray-400" datetime={post.data.date}>{post.data.date}</time>
+      </div>
+      <h3 class="mt-1 text-base font-semibold text-gray-900 group-hover:text-primary-600 sm:text-lg">
+        {post.data.title}
+      </h3>
+      {post.data.excerpt && (
+        <p class="mt-1 line-clamp-2 text-sm text-gray-500">{post.data.excerpt}</p>
+      )}
+    </div>
+  </article>
+</a>

--- a/apps/lp/src/components/sections/BlogRelatedPosts.astro
+++ b/apps/lp/src/components/sections/BlogRelatedPosts.astro
@@ -1,8 +1,8 @@
 ---
 import { useTranslations } from "@/i18n/utils";
 import type { Locale } from "@/i18n/config";
-import { getRelatedPosts, extractFirstImage } from "@/utils/blog";
-import { getCategoryColor } from "@/utils/category";
+import { getRelatedPosts } from "@/utils/blog";
+import BlogPostCard from "./BlogPostCard.astro";
 
 type Props = {
   locale: Locale;
@@ -22,39 +22,7 @@ const posts = await getRelatedPosts(currentSlug, currentCategory, locale, limit)
       {t("blog.related-title")}
     </h2>
     <div class="grid grid-cols-2 gap-3 sm:gap-4">
-      {posts.map((post) => {
-        const slug = post.id.replace(/\.md$/, "");
-        const coverImage = extractFirstImage(post.body ?? "");
-        return (
-          <a
-            href={`/${locale}/blog/${slug}/`}
-            class="group block"
-          >
-            <article class="h-full overflow-hidden rounded-xl bg-white shadow-md transition-shadow hover:shadow-lg">
-              {coverImage && (
-                <div class="aspect-video w-full overflow-hidden">
-                  <img
-                    src={coverImage}
-                    alt={post.data.title}
-                    class="size-full object-cover transition-transform group-hover:scale-105"
-                    loading="lazy"
-                  />
-                </div>
-              )}
-              <div class="px-3 py-2 sm:px-3 sm:py-2.5">
-                {post.data.category && (
-                  <span class={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium sm:text-xs ${getCategoryColor(post.data.category)}`}>
-                    {post.data.category}
-                  </span>
-                )}
-                <h3 class="mt-1 line-clamp-2 text-[13px] font-semibold leading-[1.4] text-gray-900 group-hover:text-primary-600 sm:text-sm">
-                  {post.data.title}
-                </h3>
-              </div>
-            </article>
-          </a>
-        );
-      })}
+      {posts.map((post) => <BlogPostCard post={post} locale={locale} />)}
     </div>
   </section>
 )}

--- a/apps/lp/src/pages/en/blog/index.astro
+++ b/apps/lp/src/pages/en/blog/index.astro
@@ -1,9 +1,10 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import BlogCategoryFilter from "@/components/pages/BlogCategoryFilter.astro";
+import BlogPostCard from "@/components/sections/BlogPostCard.astro";
 import { useTranslations } from "@/i18n/utils";
-import { getAllPosts, extractFirstImage } from "@/utils/blog";
-import { getCategoryColor, sortCategoriesByDefinedOrder } from "@/utils/category";
+import { getAllPosts } from "@/utils/blog";
+import { sortCategoriesByDefinedOrder } from "@/utils/category";
 
 const locale = "en";
 const t = useTranslations(locale);
@@ -43,44 +44,7 @@ const categories = sortCategoriesByDefinedOrder(
         )}
 
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {posts.map((post) => {
-            const slug = post.id.replace(/\.md$/, "");
-            const coverImage = extractFirstImage(post.body ?? "");
-            return (
-              <a
-                href={`/${locale}/blog/${slug}/`}
-                class="group block"
-                data-blog-card
-                data-category={post.data.category ?? ""}
-              >
-                <article class="h-full overflow-hidden rounded-xl bg-white shadow-md transition-shadow hover:shadow-lg">
-                  {coverImage && (
-                    <div class="aspect-video w-full overflow-hidden">
-                      <img
-                        src={coverImage}
-                        alt={post.data.title}
-                        class="size-full object-cover transition-transform group-hover:scale-105"
-                        loading="lazy"
-                      />
-                    </div>
-                  )}
-                  <div class="px-3 py-2 sm:px-4 sm:py-3">
-                    <div class="flex items-center justify-between">
-                      {post.data.category && (
-                        <span class={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${getCategoryColor(post.data.category)}`}>
-                          {post.data.category}
-                        </span>
-                      )}
-                      <time class="text-xs text-gray-400" datetime={post.data.date}>{post.data.date}</time>
-                    </div>
-                    <h3 class="mt-1 text-lg font-semibold text-gray-900 group-hover:text-primary-600">
-                      {post.data.title}
-                    </h3>
-                  </div>
-                </article>
-              </a>
-            );
-          })}
+          {posts.map((post) => <BlogPostCard post={post} locale={locale} filterable />)}
         </div>
 
         <div id="blog-filter-empty" class="hidden py-16 text-center">

--- a/apps/lp/src/pages/ja/blog/index.astro
+++ b/apps/lp/src/pages/ja/blog/index.astro
@@ -1,9 +1,10 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import BlogCategoryFilter from "@/components/pages/BlogCategoryFilter.astro";
+import BlogPostCard from "@/components/sections/BlogPostCard.astro";
 import { useTranslations } from "@/i18n/utils";
-import { getAllPosts, extractFirstImage } from "@/utils/blog";
-import { getCategoryColor, sortCategoriesByDefinedOrder } from "@/utils/category";
+import { getAllPosts } from "@/utils/blog";
+import { sortCategoriesByDefinedOrder } from "@/utils/category";
 
 const locale = "ja";
 const t = useTranslations(locale);
@@ -44,47 +45,7 @@ const categories = sortCategoriesByDefinedOrder(
         )}
 
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {posts.map((post) => {
-            const slug = post.id.replace(/\.md$/, "");
-            const coverImage = extractFirstImage(post.body ?? "");
-            return (
-              <a
-                href={`/${locale}/blog/${slug}/`}
-                class="group block"
-                data-blog-card
-                data-category={post.data.category ?? ""}
-              >
-                <article class="h-full overflow-hidden rounded-xl bg-white shadow-md transition-shadow hover:shadow-lg">
-                  {coverImage && (
-                    <div class="aspect-video w-full overflow-hidden">
-                      <img
-                        src={coverImage}
-                        alt={post.data.title}
-                        class="size-full object-cover transition-transform group-hover:scale-105"
-                        loading="lazy"
-                      />
-                    </div>
-                  )}
-                  <div class="px-3 py-2 sm:px-4 sm:py-3">
-                    <div class="flex items-center justify-between">
-                      {post.data.category && (
-                        <span class={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${getCategoryColor(post.data.category)}`}>
-                          {post.data.category}
-                        </span>
-                      )}
-                      <time class="text-xs text-gray-400" datetime={post.data.date}>{post.data.date}</time>
-                    </div>
-                    <h3 class="mt-1 text-base font-semibold text-gray-900 group-hover:text-primary-600 sm:text-lg">
-                      {post.data.title}
-                    </h3>
-                    {post.data.excerpt && (
-                      <p class="mt-1 line-clamp-2 text-sm text-gray-500">{post.data.excerpt}</p>
-                    )}
-                  </div>
-                </article>
-              </a>
-            );
-          })}
+          {posts.map((post) => <BlogPostCard post={post} locale={locale} filterable />)}
         </div>
 
         <div id="blog-filter-empty" class="hidden py-16 text-center">


### PR DESCRIPTION
## Summary
- ブログ一覧（ja/en）と関連記事セクションで3重複していたカード markup を `BlogPostCard.astro` に切り出し
- 「こちらもおすすめ」のカード見た目をブログ一覧と完全に一致させるのが主目的
- `filterable` prop で `data-blog-card` / `data-category` 属性を付与（カテゴリフィルタ対応）
- 副次的に ja/en 間の軽微なデザイン差（en で excerpt 非表示、title のレスポンシブ無し）も統一

## Test plan
- [ ] `/ja/blog/` のカードが従来と同じ見た目であること
- [ ] `/en/blog/` のカードに excerpt が表示され、title がレスポンシブになっていること
- [ ] `/ja/blog/` `/en/blog/` のカテゴリフィルタが従来通り動作すること
- [ ] `/ja/blog/<slug>/` `/en/blog/<slug>/` の「こちらもおすすめ」カードが一覧カードと同じ見た目であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)